### PR TITLE
Make CoP and flowrate numerical, round delta temp

### DIFF
--- a/custom_components/quatt/const.py
+++ b/custom_components/quatt/const.py
@@ -144,11 +144,13 @@ SENSORS = [
         name="HP1 Quatt COP",
         key="hp1.computedQuattCop",
         icon="mdi:heat-pump",
+        native_unit_of_measurement="CoP",
     ),
     SensorEntityDescription(
         name="HP1 COP",
         key="hp1.computedCop",
         icon="mdi:heat-pump",
+        native_unit_of_measurement="CoP",
     ),
     # Heatpump 2
     SensorEntityDescription(
@@ -207,7 +209,7 @@ SENSORS = [
         name="FlowMeter flowRate",
         key="flowMeter.flowRate",
         icon="mdi:gauge",
-        unit_of_measurement="l/h",
+        native_unit_of_measurement="l/h",
     ),
     # Thermostat
     SensorEntityDescription(

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -93,7 +93,7 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
             return None
         if temperatureWaterOut < temperatureWaterIn:
             return None
-        return temperatureWaterOut - temperatureWaterIn
+        return round(temperatureWaterOut - temperatureWaterIn, 2)
 
     def computedHeatPower(self):
         """Compute heatPower."""


### PR DESCRIPTION
CoP and flow rate are shown as a bar, is not possible to graph. Added native_unit_of_measurement to make it numerical. Also round delta temp to eliminate float subtraction precision error