### PR TITLE
Ignore hp2 warnings for single quatt installations #86

### DIFF
--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinator for quatt."""
+
 from __future__ import annotations
 
 from datetime import timedelta
@@ -248,8 +249,10 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
                 method = getattr(self, key)
                 return method(parent_key)
             elif key not in value:
-                LOGGER.warning("Could not find %s of %s", key, value_path)
-                LOGGER.debug("in %s", value)
+                """Ignore any warnings about hp2 - for single quatt installations it is valid that hp2 does not exist."""
+                if key != "hp2":
+                    LOGGER.warning("Could not find %s of %s", key, value_path)
+                    LOGGER.debug("in %s", value)
                 return default
             value = value[key]
             parent_key = key


### PR DESCRIPTION
This fixes issue #86. The logfile is flooded with warnings like: "Could not find hp2 of hp.temperatureWaterOut".
Warnings regarding hp2 are ignored in the getValue function because for single Quatt installations it is a valid scenario.
