### PR TITLE
DHCP autodiscovery: fixed matching CIC hostname / CIC statuspage hostname

### DIFF
--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -83,7 +83,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         # The old version does not have a unique_id so we get the CIC hostname and set it
         # Return that the migration failed in case the retrieval fails
         try:
-            new_unique_id = await _get_cic_hostname(hass=hass, ip_address=config_entry.data[CONF_IP_ADDRESS])
+            hostname_unique_id = await _get_cic_hostname(hass=hass, ip_address=config_entry.data[CONF_IP_ADDRESS])
+            # Uppercase the first 3 characters CIC-xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
+            # This enables the correct match on DHCP hostname
+            if len(hostname_unique_id) >= 3:
+                hostname_unique_id = hostname_unique_id[:3].upper() + hostname_unique_id[3:]
         except QuattApiClientAuthenticationError as exception:
             LOGGER.warning(exception)
             return False
@@ -108,7 +112,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 config_entry,
                 data=new_data,
                 options=new_options,
-                unique_id=new_unique_id,
+                unique_id=hostname_unique_id,
                 version=config_entry.version
             )
 

--- a/custom_components/quatt/config_flow.py
+++ b/custom_components/quatt/config_flow.py
@@ -124,8 +124,14 @@ class QuattFlowHandler(ConfigFlow, domain=DOMAIN):
             discovery_info.ip
         )
 
+        # Uppercase the first 3 characters CIC-xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
+        # This enables the correct match on DHCP hostname
+        hostname_unique_id = discovery_info.hostname
+        if len(hostname_unique_id) >= 3:
+            hostname_unique_id = hostname_unique_id[:3].upper() + hostname_unique_id[3:]
+
         # Check if the device is already configured
-        await self.async_set_unique_id(discovery_info.hostname)
+        await self.async_set_unique_id(hostname_unique_id)
         self.ip_address = discovery_info.ip
         self.hostname = discovery_info.hostname
 


### PR DESCRIPTION
The hostname on the CIC status page always starts with CIC in uppercase. The DHCP discovery sometimes returns the hostname with CIC in lowercase, which triggers the detection of a new Quatt device. The unique_id is now always stored with CIC in uppercase, and any comparison against the unique_id (including during DHCP autodiscovery) is also done with CIC in uppercase.
