### PR TITLE
Added support for shortened hostname in the DHCP discovery

### DIFF
--- a/custom_components/quatt/api.py
+++ b/custom_components/quatt/api.py
@@ -51,7 +51,7 @@ class QuattApiClient:
             url = "http://" + self._ip_address + ":8080" + path
 
             _LOGGER.debug("Fetching data from url: %s", url)
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(20):
                 response = await self._session.request(
                     method=method,
                     url=url,
@@ -68,12 +68,15 @@ class QuattApiClient:
                 return await response.json()
 
         except asyncio.TimeoutError as exception:
+            _LOGGER.debug("Timeout error fetching information")
             raise QuattApiClientCommunicationError(
                 "Timeout error fetching information",
             ) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
+            _LOGGER.debug("Error fetching information")
             raise QuattApiClientCommunicationError(
                 "Error fetching information",
             ) from exception
         except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.debug("Something really wrong happened!")
             raise QuattApiClientError("Something really wrong happened!") from exception


### PR DESCRIPTION
Following up on issue #106

Standard hostnames can be up to 63 characters long, but some routers shorten hostnames to 30-32 characters. The CIC hostname, however, is 40 characters long.

The Quatt CIC is detected in DHCP autodiscovery based on its hostname. Due to hostname shortening, the integration may detect a new CIC even if the CIC has already been configured with the full hostname, as found on the JSON status page.

This fix checks during DHCP discovery whether a shortened hostname matches an existing configuration. If a match is found, the discovered CIC is not marked as a new CIC.