### PR TITLE
Sensor naming updated to be more human readable

### DIFF
--- a/custom_components/quatt/binary_sensor.py
+++ b/custom_components/quatt/binary_sensor.py
@@ -15,13 +15,13 @@ from .entity import QuattEntity, QuattSensorEntityDescription
 BINARY_SENSORS = [
     # Heatpump 1
     QuattSensorEntityDescription(
-        name="HP1 silentMode",
+        name="HP1 silentmode",
         key="hp1.silentModeStatus",
         translation_key="hp_silentModeStatus",
         icon="mdi:sleep",
     ),
     QuattSensorEntityDescription(
-        name="HP1 limitedByCop",
+        name="HP1 limited by COP",
         key="hp1.limitedByCop",
         translation_key="hp_silentModeStatus",
         icon="mdi:arrow-collapse-up",
@@ -34,14 +34,14 @@ BINARY_SENSORS = [
     ),
     # Heatpump 2
     QuattSensorEntityDescription(
-        name="HP2 silentMode",
+        name="HP2 silentmode",
         key="hp2.silentModeStatus",
         translation_key="hp_silentModeStatus",
         icon="mdi:sleep",
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 limitedByCop",
+        name="HP2 limited by COP",
         key="hp2.limitedByCop",
         translation_key="hp_silentModeStatus",
         icon="mdi:arrow-collapse-up",

--- a/custom_components/quatt/binary_sensor.py
+++ b/custom_components/quatt/binary_sensor.py
@@ -70,12 +70,12 @@ BINARY_SENSORS = [
         icon="mdi:fire",
     ),
     QuattSensorEntityDescription(
-        name="Boiler heating",
+        name="Boiler CIC heating",
         key="boiler.otTbCH",
         icon="mdi:heating-coil",
     ),
     QuattSensorEntityDescription(
-        name="Boiler on/off mode",
+        name="Boiler CIC on/off",
         key="boiler.oTtbTurnOnOffBoilerOn",
         icon="mdi:water-boiler",
     ),

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -67,11 +67,11 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.debug(self.getValue("boiler.otFbChModeActive"))
         return self.getValue("boiler.otFbChModeActive") is not None
 
-    def electicalPower(self):
+    def electricalPower(self):
         """Get heatpump power from sensor."""
         if self._power_sensor_id is None:
             return None
-        LOGGER.debug("electicalPower %s", self.hass.states.get(self._power_sensor_id))
+        LOGGER.debug("electricalPower %s", self.hass.states.get(self._power_sensor_id))
         if self.hass.states.get(self._power_sensor_id) is None:
             return None
         if self.hass.states.get(self._power_sensor_id).state not in [
@@ -148,21 +148,21 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
 
     def computedCop(self, parent_key: str | None = None):
         """Compute COP."""
-        electicalPower = self.electicalPower()
+        electricalPower = self.electricalPower()
         computedHeatPower = self.computedHeatPower(parent_key)
 
-        LOGGER.debug("computedCop.electicalPower %s", electicalPower)
+        LOGGER.debug("computedCop.electricalPower %s", electricalPower)
         LOGGER.debug("computedCop.computedHeatPower %s", computedHeatPower)
 
-        if electicalPower is None or computedHeatPower is None:
+        if electricalPower is None or computedHeatPower is None:
             return None
 
         computedHeatPower = float(computedHeatPower)
-        electicalPower = float(electicalPower)
-        if electicalPower == 0:
+        electricalPower = float(electricalPower)
+        if electricalPower == 0:
             return None
 
-        return round(computedHeatPower / electicalPower, 2)
+        return round(computedHeatPower / electricalPower, 2)
 
     def computedQuattCop(self, parent_key: str | None = None):
         """Compute Quatt COP."""

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for quatt."""
+
 from __future__ import annotations
 
 import logging
@@ -27,7 +28,7 @@ SENSORS = [
         icon="mdi:auto-mode",
     ),
     QuattSensorEntityDescription(
-        name="HP1 temperatureOutside",
+        name="HP1 temperature outside",
         key="hp1.temperatureOutside",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -36,7 +37,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="HP1 temperatureWaterIn",
+        name="HP1 temperature water in",
         key="hp1.temperatureWaterIn",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -45,7 +46,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="HP1 temperatureWaterOut",
+        name="HP1 temperature water out",
         key="hp1.temperatureWaterOut",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -54,7 +55,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="HP1 waterDelta",
+        name="HP1 water delta",
         key="hp1.computedWaterDelta",
         icon="mdi:thermometer-water",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -63,16 +64,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="HP1 heatPower",
-        key="hp1.computedHeatPower",
-        icon="mdi:heat-wave",
-        native_unit_of_measurement="W",
-        device_class=SensorDeviceClass.POWER,
-        suggested_display_precision=0,
-        state_class="measurement",
-    ),
-    QuattSensorEntityDescription(
-        name="HP1 powerInput",
+        name="HP1 power input",
         key="hp1.powerInput",
         icon="mdi:lightning-bolt",
         native_unit_of_measurement="W",
@@ -97,14 +89,6 @@ SENSORS = [
         suggested_display_precision=2,
         state_class="measurement",
     ),
-    QuattSensorEntityDescription(
-        name="HP1 COP",
-        key="hp1.computedCop",
-        icon="mdi:heat-pump",
-        native_unit_of_measurement="CoP",
-        suggested_display_precision=2,
-        state_class="measurement",
-    ),
     # Heatpump 2
     QuattSensorEntityDescription(
         name="HP2 workingmode",
@@ -113,7 +97,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 temperatureOutside",
+        name="HP2 temperature outside",
         key="hp2.temperatureOutside",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -123,7 +107,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 temperatureWaterIn",
+        name="HP2 temperature water in",
         key="hp2.temperatureWaterIn",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -133,7 +117,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 temperatureWaterOut",
+        name="HP2 temperature water out",
         key="hp2.temperatureWaterOut",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -143,7 +127,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 waterDelta",
+        name="HP2 water delta",
         key="hp2.computedWaterDelta",
         icon="mdi:thermometer-water",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -153,7 +137,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="HP2 powerInput",
+        name="HP2 power input",
         key="hp2.powerInput",
         icon="mdi:lightning-bolt",
         native_unit_of_measurement="W",
@@ -183,7 +167,24 @@ SENSORS = [
     ),
     # Combined
     QuattSensorEntityDescription(
-        name="Total powerInput",
+        name="Heat power",
+        key="computedHeatPower",
+        icon="mdi:heat-wave",
+        native_unit_of_measurement="W",
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        state_class="measurement",
+    ),
+    QuattSensorEntityDescription(
+        name="COP",
+        key="computedCop",
+        icon="mdi:heat-pump",
+        native_unit_of_measurement="CoP",
+        suggested_display_precision=2,
+        state_class="measurement",
+    ),
+    QuattSensorEntityDescription(
+        name="Total power input",
         key="computedPowerInput",
         icon="mdi:lightning-bolt",
         native_unit_of_measurement="W",
@@ -205,7 +206,7 @@ SENSORS = [
         quatt_duo=True,
     ),
     QuattSensorEntityDescription(
-        name="Total waterDelta",
+        name="Total water delta",
         key="computedWaterDelta",
         icon="mdi:thermometer-water",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -246,7 +247,7 @@ SENSORS = [
     ),
     # Flowmeter
     QuattSensorEntityDescription(
-        name="FlowMeter temperature",
+        name="Flowmeter temperature",
         key="flowMeter.waterSupplyTemperature",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -255,7 +256,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="FlowMeter flowRate",
+        name="Flowmeter flowrate",
         key="qc.flowRateFiltered",
         icon="mdi:gauge",
         native_unit_of_measurement="L/h",
@@ -292,10 +293,12 @@ SENSORS = [
     ),
     # QC
     QuattSensorEntityDescription(
-        name="QC supervisoryControlMode", key="qc.supervisoryControlMode"
+        name="QC supervisory control mode code",
+        key="qc.supervisoryControlMode",
     ),
     QuattSensorEntityDescription(
-        name="QC supervisory control mode", key="qc.computedSupervisoryControlMode"
+        name="QC supervisory control mode",
+        key="qc.computedSupervisoryControlMode",
     ),
     # System
     QuattSensorEntityDescription(
@@ -338,24 +341,26 @@ class QuattSensor(QuattEntity, SensorEntity):
         super().__init__(coordinator, sensor_key)
         self.entity_description = entity_description
 
-
     @property
     def entity_registry_enabled_default(self):
         """Return whether the sensor should be enabled by default."""
         # Only check the duo property when set, enable when duo found
-        if self.entity_description.entity_registry_enabled_default and self.entity_description.quatt_duo:
+        if (
+            self.entity_description.entity_registry_enabled_default
+            and self.entity_description.quatt_duo
+        ):
             return self.coordinator.heatpump2Active()
 
         # For all other sensors
         return self.entity_description.entity_registry_enabled_default
-
 
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
         value = (
             self.coordinator.getValue(self.entity_description.key)
-            if not self.entity_description.quatt_duo or self.coordinator.heatpump2Active()
+            if not self.entity_description.quatt_duo
+            or self.coordinator.heatpump2Active()
             else None
         )
 


### PR DESCRIPTION
Updated the naming of some sensors so that they are more human readable.
Some sensornames use variable naming schemes (`temperatureWaterOut` instead of `temperature water out`)
Match boiler CIC flags in naming (prevents double "Boiler heating" sensor)

The following sensors have been renamed because the sensors apply to the whole system now instead of just HP1:
- `HP1 COP` -> `COP`
- `HP1 heatPower` -> `Heat power`
Because of the rename (name & unique_id) it is a new sensor so any historical data will stay with the original sensor (breaking change).