### PR TITLE
Added "Boiler heatpower" and "Total system power" sensors

### DIFF
--- a/custom_components/quatt/const.py
+++ b/custom_components/quatt/const.py
@@ -16,3 +16,45 @@ CONF_POWER_SENSOR = "power_sensor"
 DEFAULT_SCAN_INTERVAL: Final = 10
 MIN_SCAN_INTERVAL: Final = 5
 MAX_SCAN_INTERVAL: Final = 600
+
+# Temperature-dependent conversion factors for water in a central heating system at 2 bar pressure.
+# The table below provides specific heat capacity (c_p), density (rho), and conversion factors (k)
+# for temperatures ranging from 5°C to 80°C in steps of 5°C.
+
+# Temperature (C) | c_p (J/kg.C) | rho (kg/m^3) | Conversion Factor (k)
+# -------------------------------------------------------------------------
+# 5               | 4200.0       | 999.97       | 1.166667
+# 10              | 4192.0       | 999.70       | 1.164444
+# 15              | 4187.6       | 999.10       | 1.162889
+# 20              | 4184.1       | 998.00       | 1.161111
+# 25              | 4181.8       | 997.05       | 1.157438
+# 30              | 4184.0       | 995.67       | 1.157753
+# 35              | 4186.2       | 994.06       | 1.157931
+# 40              | 4188.4       | 992.22       | 1.157964
+# 45              | 4190.6       | 990.25       | 1.157859
+# 50              | 4192.8       | 988.05       | 1.157617
+# 55              | 4195.0       | 985.65       | 1.157243
+# 60              | 4197.2       | 983.15       | 1.156742
+# 65              | 4199.4       | 980.44       | 1.156117
+# 70              | 4201.6       | 977.63       | 1.155369
+# 75              | 4203.8       | 974.71       | 1.154503
+# 80              | 4206.0       | 971.80       | 1.153528
+# The specific heat capacity (c_p) and density (ρ) values are from the NIST Chemistry WebBook.
+CONVERSION_FACTORS = {
+    5: 1.166667,
+    10: 1.164444,
+    15: 1.162889,
+    20: 1.161111,
+    25: 1.157438,
+    30: 1.157753,
+    35: 1.157931,
+    40: 1.157964,
+    45: 1.157859,
+    50: 1.157617,
+    55: 1.157243,
+    60: 1.156742,
+    65: 1.156117,
+    70: 1.155369,
+    75: 1.154503,
+    80: 1.153528,
+}

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -153,8 +153,8 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
             2,
         )
 
-        # Prevent negative sign for 0 values (like: -0.0)
-        return math.copysign(0.0, 1) if value == 0 else value
+        # Prevent any negative numbers
+        return max(value, 0.00)
 
     def computedBoilerHeatPower(self, parent_key: str | None = None) -> float | None:
         """Compute the boiler's added heat power."""
@@ -197,8 +197,8 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
             (flowWaterTemperature - heatpumpWaterOut) * flowRate * conversionFactor, 2
         )
 
-        # Prevent negative sign for 0 values (like: -0.0)
-        return math.copysign(0.0, 1) if value == 0 else value
+        # Prevent any negative numbers
+        return max(value, 0.00)
 
     def computedSystemPower(self, parent_key: str | None = None):
         """Compute total system power."""

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -116,6 +116,17 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator):
 
     def computedHeatPower(self, parent_key: str | None = None):
         """Compute heatPower."""
+
+        # Retrieve the supervisory control mode state first
+        state = self.getValue("qc.supervisoryControlMode")
+        LOGGER.debug("computedBoilerHeatPower.supervisoryControlMode: %s", state)
+
+        # If the state is not valid or the heatpump is not active, no need to proceed
+        if state is None:
+            return None
+        if state not in [2, 3]:
+            return 0.0
+
         if self.heatpump2Active():
             computedWaterDelta = self.computedWaterDelta(None)
             temperatureWaterOut = self.getValue("hp2.temperatureWaterOut")

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -244,6 +244,15 @@ SENSORS = [
         suggested_display_precision=2,
         state_class="measurement",
     ),
+    QuattSensorEntityDescription(
+        name="Boiler heatPower",
+        key="boiler.computedBoilerHeatPower",
+        icon="mdi:heat-wave",
+        native_unit_of_measurement="W",
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        state_class="measurement",
+    ),
     # Flowmeter
     QuattSensorEntityDescription(
         name="FlowMeter temperature",

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -188,7 +188,6 @@ SENSORS = [
         icon="mdi:lightning-bolt",
         native_unit_of_measurement="W",
         device_class=SensorDeviceClass.POWER,
-        entity_registry_enabled_default=False,
         suggested_display_precision=0,
         state_class="measurement",
         quatt_duo=True,
@@ -199,10 +198,18 @@ SENSORS = [
         icon="mdi:heat-wave",
         native_unit_of_measurement="W",
         device_class=SensorDeviceClass.POWER,
-        entity_registry_enabled_default=False,
         suggested_display_precision=0,
         state_class="measurement",
         quatt_duo=True,
+    ),
+    QuattSensorEntityDescription(
+        name="Total system power",
+        key="computedSystemPower",
+        icon="mdi:heat-wave",
+        native_unit_of_measurement="W",
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        state_class="measurement",
     ),
     QuattSensorEntityDescription(
         name="Total waterDelta",
@@ -210,7 +217,6 @@ SENSORS = [
         icon="mdi:thermometer-water",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
-        entity_registry_enabled_default=False,
         suggested_display_precision=2,
         state_class="measurement",
         quatt_duo=True,
@@ -220,7 +226,6 @@ SENSORS = [
         key="computedQuattCop",
         icon="mdi:heat-pump",
         native_unit_of_measurement="CoP",
-        entity_registry_enabled_default=False,
         suggested_display_precision=2,
         state_class="measurement",
         quatt_duo=True,
@@ -301,10 +306,12 @@ SENSORS = [
     ),
     # QC
     QuattSensorEntityDescription(
-        name="QC supervisoryControlMode", key="qc.supervisoryControlMode"
+        name="QC supervisoryControlMode",
+        key="qc.supervisoryControlMode"
     ),
     QuattSensorEntityDescription(
-        name="QC supervisory control mode", key="qc.computedSupervisoryControlMode"
+        name="QC supervisory control mode",
+        key="qc.computedSupervisoryControlMode"
     ),
     # System
     QuattSensorEntityDescription(

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.const import EntityCategory, UnitOfTemperature
 import homeassistant.util.dt as dt_util
 
@@ -209,7 +213,7 @@ SENSORS = [
         native_unit_of_measurement="W",
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
-        state_class="measurement",
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     QuattSensorEntityDescription(
         name="Total waterDelta",
@@ -256,7 +260,7 @@ SENSORS = [
         native_unit_of_measurement="W",
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
-        state_class="measurement",
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     # Flowmeter
     QuattSensorEntityDescription(

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -250,7 +250,7 @@ SENSORS = [
         state_class="measurement",
     ),
     QuattSensorEntityDescription(
-        name="Boiler heatPower",
+        name="Boiler heat power",
         key="boiler.computedBoilerHeatPower",
         icon="mdi:heat-wave",
         native_unit_of_measurement="W",


### PR DESCRIPTION
The "Boiler heatpower" sensor calculates the added heatpower by the boiler when the boiler is active.
The "Total system power" sensor calculates the total heatpower generated by the heatpumps and boiler.

It calculates the waterdelta between the heatpumps (HP1 or HP2 - depending on the configuration) and the temperature of the water at the flowmeter and multiplies it with the flowrate and the conversion factor

`BoilerHeatpower = (flowWaterTemperature - heatpumpWaterOut) * flowRate * conversionFactor`

With this value and some helper sensors an estamation can be made regarding how much gas has been used by the boiler for heating.

The `conversionFactor` has been brought in line with the Quatt calculation and "Heat transfer equation"

The Quatt `power` sensor cannot go negative anymore since CIC version 2.20.2. The calculated `heat power` sensors now show the same behaviour.