### PR TITLE
Only enable OpenTherm boiler sensors when opentherm connection is detected

### DIFF
--- a/custom_components/quatt/binary_sensor.py
+++ b/custom_components/quatt/binary_sensor.py
@@ -58,16 +58,19 @@ BINARY_SENSORS = [
         name="Boiler heating",
         key="boiler.otFbChModeActive",
         icon="mdi:heating-coil",
+        quatt_opentherm=True,
     ),
     QuattSensorEntityDescription(
         name="Boiler domestic hot water",
         key="boiler.otFbDhwActive",
         icon="mdi:water-boiler",
+        quatt_opentherm=True,
     ),
     QuattSensorEntityDescription(
         name="Boiler flame",
         key="boiler.otFbFlameOn",
         icon="mdi:fire",
+        quatt_opentherm=True,
     ),
     QuattSensorEntityDescription(
         name="Boiler heating",
@@ -136,12 +139,17 @@ class QuattBinarySensor(QuattEntity, BinarySensorEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return whether the sensor should be enabled by default."""
-        # Only check the duo property when set, enable when duo found
-        if self.entity_description.entity_registry_enabled_default and self.entity_description.quatt_duo:
-            return self.coordinator.heatpump2Active()
+        value = self.entity_description.entity_registry_enabled_default
 
-        # For all other sensors
-        return self.entity_description.entity_registry_enabled_default
+        # Only check the duo property when set, enable when duo found
+        if value and self.entity_description.quatt_duo:
+            value = self.coordinator.heatpump2Active()
+
+        # Only check the openthern when set, enable when opentherm found
+        if value and self.entity_description.quatt_opentherm:
+            value = self.coordinator.boilerOpenTherm()
+
+        return value
 
 
     @property

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -13,6 +13,7 @@ class QuattSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=Tru
     """A class that describes Quatt sensor entities."""
 
     quatt_duo: bool = False
+    quatt_opentherm: bool = False
 
 
 class QuattEntity(CoordinatorEntity):

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -234,6 +234,7 @@ SENSORS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=2,
         state_class="measurement",
+        quatt_opentherm=True,
     ),
     QuattSensorEntityDescription(
         name="Boiler temperature water outlet",
@@ -243,6 +244,7 @@ SENSORS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=2,
         state_class="measurement",
+        quatt_opentherm=True,
     ),
     # Flowmeter
     QuattSensorEntityDescription(
@@ -342,12 +344,17 @@ class QuattSensor(QuattEntity, SensorEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return whether the sensor should be enabled by default."""
-        # Only check the duo property when set, enable when duo found
-        if self.entity_description.entity_registry_enabled_default and self.entity_description.quatt_duo:
-            return self.coordinator.heatpump2Active()
+        value = self.entity_description.entity_registry_enabled_default
 
-        # For all other sensors
-        return self.entity_description.entity_registry_enabled_default
+        # Only check the duo property when set, enable when duo found
+        if value and self.entity_description.quatt_duo:
+            value = self.coordinator.heatpump2Active()
+
+        # Only check the openthern when set, enable when opentherm found
+        if value and self.entity_description.quatt_opentherm:
+            value = self.coordinator.boilerOpenTherm()
+
+        return value
 
 
     @property


### PR DESCRIPTION
In on/off mode the opentherm boiler sensors are not available. These sensors are now automatically disabled when an opentherm connection is not detected.