### PR TITLE
Fixed warning #149: 'L/h' is not a valid unit for the device class ('volume_flow_rate')

### DIFF
--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -280,7 +280,6 @@ SENSORS = [
         key="qc.flowRateFiltered",
         icon="mdi:gauge",
         native_unit_of_measurement="L/h",
-        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
Removed SensorDeviceClass.VOLUME_FLOW_RATE from "Flowmeter flowrate" because it does not support L/h and only supports L/min. Converting to L/min would break the history. As soon as Home Assistant supports L/h, we can add it back.