### PR TITLE
Initial All-Electric implementation

### DIFF
--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -12,6 +12,8 @@ from .coordinator import QuattDataUpdateCoordinator
 class QuattSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=True):
     """A class that describes Quatt sensor entities."""
 
+    quatt_hybrid: bool = False
+    quatt_all_electric: bool = False
     quatt_duo: bool = False
     quatt_opentherm: bool = False
 


### PR DESCRIPTION
Initial All-Electric implementation:
- Added the `hc.electricalPower` sensor
- Automatically disable all the `boiler` sensors because those are not available in an all-electric installation
- Updated the `Total system power` sensor to take the `hc.electricalPower` sensor into account for an all-electric installation