### PR TITLE
Use constant for flowrate

### DIFF
--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfPressure,
     UnitOfTemperature,
+    UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
@@ -309,7 +310,7 @@ SENSORS = [
         name="Flowmeter flowrate",
         key="qc.flowRateFiltered",
         icon="mdi:gauge",
-        native_unit_of_measurement="L/h",
+        native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_HOUR,
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Quatt",
     "filename": "quatt.zip",
     "hide_default_branch": true,
-    "homeassistant": "2022.2.0",
+    "homeassistant": "2025.5.0",
     "render_readme": true,
     "zip_release": true
 }


### PR DESCRIPTION
Home Assistant 2025.5.0 introduced the constant UnitOfVolumeFlowRate.LITERS_PER_HOUR.
Sensor `Flowmeter flowrate` has been updated to use this constant.