### PR TITLE
show heat battery percentage as a battery

### DIFF
--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -767,7 +767,7 @@ SENSORS = {
         QuattSensorEntityDescription(
             name="Percentage",
             key="allEStatus.heatBatteryPercentage",
-            icon="mdi:battery",
+            device_class=SensorDeviceClass.BATTERY,
             native_unit_of_measurement=PERCENTAGE,
             suggested_display_precision=0,
             state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Show the heat battery percentage as a battery, so the icon will change based on the percentage value.