### PR TITLE
Fix warning logging for expired token

### DIFF
--- a/custom_components/quatt/api_remote.py
+++ b/custom_components/quatt/api_remote.py
@@ -537,7 +537,7 @@ class QuattRemoteApiClient(QuattApiClient):
 
                 # Handle 401 Unauthorized or 403 Forbidden - token might be expired
                 if response.status in (401, 403) and retry_on_403:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Got %s, attempting to refresh token", response.status
                     )
                     if await self.refresh_token():
@@ -600,7 +600,7 @@ class QuattRemoteApiClient(QuattApiClient):
 
                 # Handle 401 Unauthorized or 403 Forbidden - token might be expired
                 if response.status in (401, 403):
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Got %s while updating CIC settings, attempting to refresh token",
                         response.status,
                     )


### PR DESCRIPTION
see: https://github.com/marcoboers/home-assistant-quatt/issues/218