### PR TITLE
Correct defrost computation

### DIFF
--- a/custom_components/quatt/coordinator_local.py
+++ b/custom_components/quatt/coordinator_local.py
@@ -299,7 +299,7 @@ class QuattLocalDataUpdateCoordinator(QuattDataUpdateCoordinator):
                 SupervisoryControlMode.HEATING_HEATPUMP_ONLY,
                 SupervisoryControlMode.HEATING_HEATPUMP_PLUS_BOILER,
             ]
-            and power_output == 0
+            and power_output < -1
             and water_delta < -1
         )
 


### PR DESCRIPTION
Quatt updated their calculation of power usage. When a defrost cycle is running the power output is now negative.

This PR updates the calculation to fix the computed sensor. I have been running a helper locally on my homeassistant and that seems to work.

closes #239 