### PR TITLE
Fix difference in HP1 and HP2 working mode displaying heat pipe

### DIFF
--- a/custom_components/quatt/www/quatt-dashboard-card.js
+++ b/custom_components/quatt/www/quatt-dashboard-card.js
@@ -843,6 +843,7 @@ class QuattDashboardCard extends LitElement {
                 && this.getSensorState('boiler.boiler_heating')?.state == 'on'
                   ? svg`<g id="quatt.chimneyPipe">
                           <path d="M 347 1125 L 348 1205" stroke="url(#waterGradientDown)" stroke-width="8" fill="none" stroke-linecap="round"/>
+                          <path d="M 317 1123 L 318 1225" stroke="url(#waterGradientDown)" stroke-width="8" fill="none" stroke-linecap="round"/>
                       </g>
                       <g id="quatt.chimneySmoke">
                           <ellipse cx="400" cy="675" rx="12" ry="15" fill="#6B6B6B" filter="url(#smokeBlur)">


### PR DESCRIPTION
Fixes the heat pipe to be displayed correctly based on if HP1 or HP2 is working. 

For example, if you have duo setup, and HP2 is running, than the middle piece of pipe shoulnt be orange (according to the quatt app) 