### PR TITLE
Example and documenation update for retrieving insights once per hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ scripts.yaml
 secrets.yaml
 /.vs
 /custom_components/quatt/www/dev
+/test

--- a/examples/automation_quatt_insights.yaml
+++ b/examples/automation_quatt_insights.yaml
@@ -2,7 +2,7 @@ alias: Quatt Insights (today - refresh every 10 min)
 description: ""
 triggers:
   - trigger: time_pattern
-    minutes: /10
+    minutes: "15"
   - trigger: homeassistant
     event: start
 conditions: []


### PR DESCRIPTION
Insights are updated once an hour according to Quatt. so it is of no use to request it more often.

The Quatt insights example and documenation has been updated accordingly