### PR TITLE
Change card config for cic_central_heating_on to remote

### DIFF
--- a/custom_components/quatt/www/js/quatt-dashboard-card-editor.js
+++ b/custom_components/quatt/www/js/quatt-dashboard-card-editor.js
@@ -330,7 +330,7 @@ class QuattDashboardCardEditor extends LitElement {
             // CIC
             total_power: "Provided by local API",
             total_powerinput: "Provided by local API",
-            cic_central_heating_on: "Provided by local API",
+            cic_central_heating_on: "Provided by remote API",
 
             // Flowmeter
             flowmeter_temperature: "Provided by local API",


### PR DESCRIPTION
The cic_central_heating_on is part of the remote API and not the local API.
This should be reflected in the Quatt card configuration.