### PR TITLE
Add number platform with CH max water temperature setting

### DIFF
--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -54,6 +54,7 @@ from .coordinator_remote import QuattRemoteDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -7,11 +7,13 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 import logging
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -381,6 +383,132 @@ class QuattSettingSwitch(QuattSwitch):
         return await remote_client.update_cic_settings(settings)
 
 
+class QuattNumber(QuattEntity, NumberEntity):
+    """Quatt Number class."""
+
+    def __init__(
+        self,
+        device_name: str,
+        device_id: str,
+        sensor_key: str,
+        coordinator: QuattDataUpdateCoordinator,
+        entity_description: QuattNumberEntityDescription,
+        device_kind: QuattDeviceKind,
+    ) -> None:
+        """Initialize the number class."""
+        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        self.entity_description = entity_description
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Return whether the number should be enabled by default."""
+        return self.entity_description.entity_registry_enabled_default
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        return self.coordinator.get_value(f"{self.entity_description.key}.value")
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        value = self.coordinator.get_value(f"{self.entity_description.key}.minValue")
+        if value is None:
+            return super().native_min_value
+        return value
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        value = self.coordinator.get_value(f"{self.entity_description.key}.maxValue")
+        if value is None:
+            return super().native_max_value
+        return value
+
+    @property
+    def native_step(self) -> float | None:
+        """Return the step value."""
+        value = self.coordinator.get_value(f"{self.entity_description.key}.increment")
+        if value is None:
+            return super().native_step
+        return value
+
+    def set_native_value(self, value: float) -> None:
+        """Implement required base class method but do not use it (async handled separately)."""
+        raise NotImplementedError("Use async_set_native_value instead")
+
+    @abstractmethod
+    async def _perform_api_update(self, value: float) -> bool:
+        """Perform the API call to update this setting.
+
+        Must return True if the update succeeded, False otherwise.
+        """
+        raise NotImplementedError
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the new value."""
+        # Only remote coordinator supports updating settings
+        if not isinstance(self.coordinator, QuattRemoteDataUpdateCoordinator):
+            _LOGGER.error(
+                "Cannot update %s: only available via remote API",
+                self.entity_description.key,
+            )
+            raise NotImplementedError(
+                f"Setting {self.entity_description.key} is only available via remote API"
+            )
+
+        success = False
+        try:
+            success = await self._perform_api_update(value)
+        except Exception as err:
+            _LOGGER.exception("Error updating %s", self.entity_description.key)
+            raise RuntimeError(
+                f"Failed to update {self.entity_description.key}"
+            ) from err
+
+        if not success:
+            _LOGGER.warning("Failed to update %s", self.entity_description.key)
+            raise RuntimeError(f"Failed to update {self.entity_description.key}")
+
+        # Always refresh coordinator data after a successful update
+        await self.coordinator.async_request_refresh()
+
+
+class QuattSettingNumber(QuattNumber):
+    """Number entity for Quatt numeric settings stored as {value, minValue, maxValue, increment}."""
+
+    async def _perform_api_update(self, value: float) -> bool:
+        """Perform numeric setting update."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattRemoteApiClient):
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
+            return False
+
+        # Preserve integer type when the step is whole-number
+        step = self.native_step
+        if step is not None and float(step).is_integer() and float(value).is_integer():
+            payload_value: int | float = int(value)
+        else:
+            payload_value = value
+
+        # Convert dot notation to nested object structure ending at ".value"
+        key_parts = self.entity_description.key.split(".") + ["value"]
+
+        settings: dict[str, Any] = {}
+        current = settings
+        for i, part in enumerate(key_parts):
+            if i == len(key_parts) - 1:
+                current[part] = payload_value
+            else:
+                current[part] = {}
+                current = current[part]
+
+        _LOGGER.debug("Updating CIC setting: %s", settings)
+        return await remote_client.update_cic_settings(settings)
+
+
 @dataclass(frozen=True)
 class QuattFeatureFlags:
     """Quatt feature flags used an entity."""
@@ -420,3 +548,10 @@ class QuattSwitchEntityDescription(SwitchEntityDescription, frozen_or_thawed=Tru
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSwitch
+
+
+class QuattNumberEntityDescription(NumberEntityDescription, frozen_or_thawed=True):
+    """A class that describes Quatt number entities."""
+
+    quatt_features: QuattFeatureFlags = QuattFeatureFlags()
+    quatt_entity_class: type[QuattEntity] = QuattNumber

--- a/custom_components/quatt/number.py
+++ b/custom_components/quatt/number.py
@@ -1,0 +1,85 @@
+"""Number platform for quatt."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberMode
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEVICE_BOILER_ID,
+    DEVICE_CIC_ID,
+    DEVICE_FLOWMETER_ID,
+    DEVICE_HEAT_BATTERY_ID,
+    DEVICE_HEAT_CHARGER_ID,
+    DEVICE_HEATPUMP_1_ID,
+    DEVICE_HEATPUMP_2_ID,
+    DEVICE_THERMOSTAT_ID,
+    DOMAIN,
+)
+from .coordinator import QuattDataUpdateCoordinator
+from .entity import (
+    QuattFeatureFlags,
+    QuattNumber,
+    QuattNumberEntityDescription,
+    QuattSettingNumber,
+)
+from .entity_setup import async_setup_entities
+
+NUMBERS = {
+    # The HUB CIC sensor must be created first to ensure the HUB device is present
+    DEVICE_CIC_ID: [
+        QuattNumberEntityDescription(
+            key="chMaxWaterTemperature",
+            name="Max water temperature",
+            icon="mdi:thermometer-high",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            mode=NumberMode.BOX,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattSettingNumber,
+        ),
+    ],
+    DEVICE_HEAT_BATTERY_ID: [],
+    DEVICE_HEAT_CHARGER_ID: [],
+    DEVICE_HEATPUMP_1_ID: [],
+    DEVICE_HEATPUMP_2_ID: [],
+    DEVICE_BOILER_ID: [],
+    DEVICE_FLOWMETER_ID: [],
+    DEVICE_THERMOSTAT_ID: [],
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the number platform."""
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+
+    local_coordinator: QuattDataUpdateCoordinator = coordinators["local"]
+    remote_coordinator: QuattDataUpdateCoordinator = coordinators["remote"]
+
+    numbers: list[QuattNumber] = []
+    numbers += await async_setup_entities(
+        hass=hass,
+        coordinator=local_coordinator,
+        entry=entry,
+        remote=False,
+        entity_descriptions=NUMBERS,
+        entity_domain=NUMBER_DOMAIN,
+    )
+
+    if remote_coordinator:
+        numbers += await async_setup_entities(
+            hass=hass,
+            coordinator=remote_coordinator,
+            entry=entry,
+            remote=True,
+            entity_descriptions=NUMBERS,
+            entity_domain=NUMBER_DOMAIN,
+        )
+
+    async_add_devices(numbers)


### PR DESCRIPTION
## Summary

Introduces a new Home Assistant **Number** platform for Quatt, providing a
generic foundation for numeric settings that live on the Quatt remote
(mobile) API. Ships the first such setting: **CH max water temperature**
on the CIC device.

Previously, numeric settings like the central-heating max water
temperature could only be changed via the Quatt app. They are now
exposed as standard Home Assistant `number` entities, which makes them
scriptable, automatable, and viewable in dashboards.

## Changes

- **`custom_components/quatt/number.py`** — new platform module.
  - Sets up numbers for both the local and (when configured) remote
    coordinators using the shared `async_setup_entities` helper.
  - Declares the initial `NUMBERS` map with `chMaxWaterTemperature`
    on the CIC device, gated behind the `mobile_api` feature flag so
    it only appears when the remote API is actually available.
- **`custom_components/quatt/entity.py`** — new base classes.
  - `QuattNumber` (abstract) — a `NumberEntity` that derives
    `native_value`, `native_min_value`, `native_max_value`, and
    `native_step` from the Quatt API response structure
    (`.value`, `.minValue`, `.maxValue`, `.increment`), falling back
    to the `NumberEntity` defaults when a field is not provided.
    Writes are gated to the remote coordinator and wrapped with
    logging + error propagation, followed by a coordinator refresh.
  - `QuattSettingNumber` — concrete implementation that converts the
    entity's dot-notation key into the nested payload shape expected
    by `update_cic_settings`, preserving integer types when the
    configured step is whole-number (so a setpoint of `45` isn't sent
    as `45.0`).
  - `QuattNumberEntityDescription` — entity description class mirroring
    the existing `QuattSwitchEntityDescription` pattern, with
    `quatt_features` and `quatt_entity_class` hooks.
- **`custom_components/quatt/__init__.py`** — registers
  `Platform.NUMBER` so Home Assistant loads the new platform.

## Design notes

- Reuses the existing `QuattEntity` / `QuattFeatureFlags` /
  `async_setup_entities` plumbing, so adding further numeric settings
  in the future is a one-line entry in the `NUMBERS` map — no extra
  wiring required.
- Min/max/step are pulled dynamically from the API response rather
  than hardcoded, so the UI automatically reflects whatever bounds
  the CIC advertises.
- Updates go through the remote coordinator only. On local-only
  setups the entity still appears read-only-friendly; attempting to
  write raises a clear `NotImplementedError` explaining the remote
  API is required.

## Test plan

- [ ] Install on a Home Assistant instance with **remote API**
      configured and verify that the `Max water temperature` number
      entity appears on the CIC device.
- [ ] Confirm the entity's min/max/step match what the Quatt app shows.
- [ ] Change the value from Home Assistant and verify:
      - [ ] the new value is reflected in the Quatt app,
      - [ ] the coordinator refresh picks up the updated value,
      - [ ] no errors in the Home Assistant logs.
- [ ] Install on a **local-only** setup and verify the entity is
      absent (gated by `mobile_api` feature flag).
- [ ] Verify existing binary_sensor / sensor / select / switch
      platforms still load correctly alongside the new number platform.