### PR TITLE
Add German, French and Spanish translations

### DIFF
--- a/custom_components/quatt/translations/de.json
+++ b/custom_components/quatt/translations/de.json
@@ -1,0 +1,139 @@
+{
+    "config": {
+        "flow_title": "CIC: {name}",
+        "step": {
+            "user": {
+                "title": "Quatt-Gerät",
+                "description": "Welche Art von Quatt-Gerät möchten Sie hinzufügen?",
+                "menu_options": {
+                    "local": "Wärmepumpe (CIC)",
+                    "home_battery": "Heimspeicher",
+                    "energy": "Energie (mijnenergie)"
+                }
+            },
+            "local": {
+                "description": "Lokale Verbindung zur Quatt-Wärmepumpe einrichten.",
+                "data": {
+                    "ip_address": "IP-Adresse / Hostname",
+                    "add_remote": "Externe Verbindung aktivieren"
+                },
+                "data_description": {
+                    "ip_address": "Ohne http:// und Port.",
+                    "add_remote": "Externe Konnektivität über die mobile Quatt-API hinzufügen, um zusätzliche Daten der Wärmepumpe abzurufen."
+                }
+            },
+            "home_battery": {
+                "title": "Mit einem Quatt-Heimspeicher koppeln",
+                "menu_options": {
+                    "home_battery_qr": "QR-Code scannen",
+                    "home_battery_manual": "Daten manuell eingeben"
+                }
+            },
+            "home_battery_qr": {
+                "title": "Koppeln per QR-Code",
+                "description": "Scannen Sie den QR-Code auf dem Heimspeicher und fügen Sie die URL unten ein.\n\n![Position des QR-Code-Etiketts am Heimspeicher](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_qr_url": "QR-Code-URL"
+                },
+                "data_description": {
+                    "home_battery_qr_url": "Scannen Sie den QR-Code und kopieren Sie den Link:\n- **iOS**: QR-Vorschlag lange drücken → Link kopieren\n- **Android**: Google Lens / Kamera-Scan → Kopieren\n- Jede Barcode-App (ZXing, Binary Eye), die den Rohtext anzeigt"
+                }
+            },
+            "home_battery_manual": {
+                "title": "Manuell koppeln",
+                "description": "Geben Sie die **UUID**, die **Seriennummer** und den **Prüfcode** vom Etikett des Heimspeichers ein.\n\n![Position des Kopplungsetiketts am Heimspeicher](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_uuid": "UUID",
+                    "home_battery_serial": "Seriennummer",
+                    "home_battery_check_code": "Prüfcode"
+                }
+            },
+            "auth": {
+                "title": "Bei der mobilen Quatt-API anmelden",
+                "description": "Geben Sie Ihren Namen ein, um ein anonymes Konto bei der mobilen Quatt-API zu erstellen. Diese Daten werden ausschließlich lokal in Home Assistant gespeichert und für alle Quatt-Geräte wiederverwendet, die Sie hinzufügen.",
+                "data": {
+                    "first_name": "Vorname",
+                    "last_name": "Nachname"
+                }
+            },
+            "pair": {
+                "title": "Mit dem Quatt-Gerät koppeln",
+                "description": "Drücken Sie die Taste an Ihrem CIC-Gerät, um die Kopplung abzuschließen.\n\n> **{cic}**\n\n![Position der Kopplungstaste](/quatt_static/pair.png)\nSchließen Sie die Kopplung innerhalb von 60 Sekunden ab.\n\nDrücken Sie 'Senden', um den Kopplungsvorgang zu starten, und warten Sie auf die Bestätigung."
+            },
+            "confirm": {
+                "description": "Klicken Sie auf 'Senden', um die Einrichtung zu bestätigen."
+            },
+            "energy": {
+                "title": "Bei mijnenergie.quatt.io anmelden",
+                "description": "Geben Sie die E-Mail-Adresse und das Passwort ein, die Sie auf {portal_url} verwenden. Die Anmeldedaten werden ausschließlich lokal in Home Assistant gespeichert und verwendet, um die Sitzung aktiv zu halten.",
+                "data": {
+                    "energy_username": "E-Mail-Adresse",
+                    "energy_password": "Passwort"
+                }
+            }
+        },
+        "error": {
+            "auth": "Authentifizierung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten.",
+            "cannot_connect": "Verbindung zum lokalen CIC nicht möglich. Bitte überprüfen Sie die IP-Adresse.",
+            "pairing_timeout": "Zeitüberschreitung beim Koppeln. Bitte versuchen Sie es erneut und drücken Sie innerhalb von 60 Sekunden die Taste am CIC-Gerät.",
+            "home_battery_qr_invalid": "Ungültige QR-Code-URL. Stellen Sie sicher, dass Sie die vollständige URL des Heimspeicher-QR-Codes kopieren.",
+            "home_battery_pair_failed": "Kopplung des Heimspeichers fehlgeschlagen. Bitte überprüfen Sie den Zugriffsschlüssel, die Seriennummer und den Prüfcode.",
+            "energy_no_ean": "Anmeldung erfolgreich, aber es wurde kein Energiezähler (EAN) zurückgegeben. Öffnen Sie das Quatt-Energieportal einmal in einem Browser, um die Einrichtung abzuschließen, und versuchen Sie es dann erneut.",
+            "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+        },
+        "abort": {
+            "already_in_progress": "Für dieses Quatt-Gerät läuft bereits ein Konfigurationsvorgang.",
+            "already_configured": "Gerät ist bereits konfiguriert.",
+            "no_match": "Kein passendes Quatt-Gerät gefunden."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Quatt-Optionen",
+                "data": {
+                    "scan_interval": "Lokales Aktualisierungsintervall (Sekunden)",
+                    "remote_scan_interval": "Aktualisierungsintervall der mobilen API (Minuten)",
+                    "power_sensor": "Leistungssensor (optional)",
+                    "add_remote": "Externe Verbindung aktivieren",
+                    "energy_password": "Quatt Energy-Passwort"
+                },
+                "data_description": {
+                    "scan_interval": "Anzahl der Sekunden zwischen den Datenabfragen vom Quatt.",
+                    "remote_scan_interval": "Anzahl der Minuten zwischen den Datenabfragen über die mobile Quatt-API.",
+                    "power_sensor": "Externer Energiesensor, der den aktuellen Energieverbrauch des Quatt misst.",
+                    "add_remote": "Externe Konnektivität über die mobile Quatt-API hinzufügen, um zusätzliche Daten der Wärmepumpe abzurufen.",
+                    "energy_password": "Nur aktualisieren, wenn Sie Ihr Passwort auf mijnenergie.quatt.io geändert haben."
+                }
+            },
+            "remote": {
+                "description": "Externe Verbindung zur Quatt-Wärmepumpe über die mobile API einrichten.\nGeben Sie die CIC-ID ein (z. B. CIC-xxxx-xxxx-xxxx).",
+                "data": {
+                    "cic": "CIC-ID"
+                }
+            },
+            "auth": {
+                "title": "Bei der mobilen Quatt-API anmelden",
+                "description": "Geben Sie Ihren Namen ein, um ein anonymes Konto bei der mobilen Quatt-API zu erstellen. Diese Daten werden ausschließlich lokal in Home Assistant gespeichert und für alle Quatt-Geräte wiederverwendet, die Sie hinzufügen.",
+                "data": {
+                    "first_name": "Vorname",
+                    "last_name": "Nachname"
+                }
+            },
+            "pair": {
+                "title": "Mit dem Quatt-Gerät koppeln",
+                "description": "Drücken Sie die Taste an Ihrem CIC-Gerät, um die Kopplung abzuschließen.\n\n> **{cic}**\n\n![Position der Kopplungstaste](/quatt_static/pair.png)\nSchließen Sie die Kopplung innerhalb von 60 Sekunden ab.\n\nDrücken Sie 'Senden', um den Kopplungsvorgang zu starten, und warten Sie auf die Bestätigung."
+            },
+            "confirm": {
+                "description": "Klicken Sie auf 'Senden', um die Einrichtung zu bestätigen."
+            }
+        },
+        "error": {
+            "auth": "Authentifizierung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten.",
+            "cannot_connect": "Verbindung zum lokalen CIC nicht möglich. Bitte überprüfen Sie die IP-Adresse.",
+            "pairing_timeout": "Zeitüberschreitung beim Koppeln. Bitte versuchen Sie es erneut und drücken Sie innerhalb von 60 Sekunden die Taste am CIC-Gerät.",
+            "energy_no_ean": "Anmeldung erfolgreich, aber es wurde kein Energiezähler (EAN) zurückgegeben.",
+            "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+        }
+    }
+}

--- a/custom_components/quatt/translations/es.json
+++ b/custom_components/quatt/translations/es.json
@@ -1,0 +1,139 @@
+{
+    "config": {
+        "flow_title": "CIC: {name}",
+        "step": {
+            "user": {
+                "title": "Dispositivo Quatt",
+                "description": "¿Qué tipo de dispositivo Quatt deseas añadir?",
+                "menu_options": {
+                    "local": "Bomba de calor (CIC)",
+                    "home_battery": "Batería doméstica",
+                    "energy": "Energía (mijnenergie)"
+                }
+            },
+            "local": {
+                "description": "Configurar la conexión local con la bomba de calor Quatt.",
+                "data": {
+                    "ip_address": "Dirección IP / nombre de host",
+                    "add_remote": "Activar la configuración de conexión remota"
+                },
+                "data_description": {
+                    "ip_address": "Sin http:// ni puerto.",
+                    "add_remote": "Añadir conectividad remota a través de la API móvil de Quatt para obtener datos adicionales de la bomba de calor."
+                }
+            },
+            "home_battery": {
+                "title": "Emparejar con una batería doméstica Quatt",
+                "menu_options": {
+                    "home_battery_qr": "Escanear código QR",
+                    "home_battery_manual": "Introducir los datos manualmente"
+                }
+            },
+            "home_battery_qr": {
+                "title": "Emparejar mediante código QR",
+                "description": "Escanea el código QR de la batería y pega la URL a continuación.\n\n![Ubicación de la etiqueta del código QR de la batería](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_qr_url": "URL del código QR"
+                },
+                "data_description": {
+                    "home_battery_qr_url": "Escanea el código QR y copia el enlace:\n- **iOS**: mantén pulsada la sugerencia del QR → Copiar enlace\n- **Android**: Google Lens / escaneo con la cámara → Copiar\n- Cualquier aplicación de códigos de barras (ZXing, Binary Eye) que muestre el texto sin procesar"
+                }
+            },
+            "home_battery_manual": {
+                "title": "Emparejar manualmente",
+                "description": "Introduce el **UUID**, el **número de serie** y el **código de verificación** que figuran en la etiqueta de la batería.\n\n![Ubicación de la etiqueta de emparejamiento de la batería](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_uuid": "UUID",
+                    "home_battery_serial": "Número de serie",
+                    "home_battery_check_code": "Código de verificación"
+                }
+            },
+            "auth": {
+                "title": "Iniciar sesión en la API móvil de Quatt",
+                "description": "Introduce tu nombre para crear una cuenta anónima en la API móvil de Quatt. Estos datos solo se almacenan localmente en Home Assistant y se reutilizan para todos los dispositivos Quatt que añadas.",
+                "data": {
+                    "first_name": "Nombre",
+                    "last_name": "Apellidos"
+                }
+            },
+            "pair": {
+                "title": "Emparejar con el dispositivo Quatt",
+                "description": "Pulsa el botón del dispositivo CIC para completar el emparejamiento.\n\n> **{cic}**\n\n![Ubicación del botón de emparejamiento](/quatt_static/pair.png)\nCompleta el emparejamiento en 60 segundos.\n\nPulsa «Enviar» para iniciar el proceso de emparejamiento y espera la confirmación."
+            },
+            "confirm": {
+                "description": "Pulsa «Enviar» para confirmar la configuración."
+            },
+            "energy": {
+                "title": "Iniciar sesión en mijnenergie.quatt.io",
+                "description": "Introduce la dirección de correo electrónico y la contraseña que utilizas en {portal_url}. Las credenciales se almacenan localmente en Home Assistant y se utilizan para mantener la sesión activa.",
+                "data": {
+                    "energy_username": "Dirección de correo electrónico",
+                    "energy_password": "Contraseña"
+                }
+            }
+        },
+        "error": {
+            "auth": "Error de autenticación. Comprueba tus credenciales.",
+            "cannot_connect": "No se puede conectar con el CIC local. Comprueba la dirección IP.",
+            "pairing_timeout": "Tiempo de emparejamiento agotado. Inténtalo de nuevo y pulsa el botón del dispositivo CIC en menos de 60 segundos.",
+            "home_battery_qr_invalid": "URL del código QR no válida. Asegúrate de copiar la URL completa del código QR de la batería.",
+            "home_battery_pair_failed": "Error al emparejar la batería doméstica. Comprueba la clave de acceso, el número de serie y el código de verificación.",
+            "energy_no_ean": "Inicio de sesión correcto, pero no se ha devuelto ningún contador de energía (EAN). Abre una vez el portal de energía de Quatt en un navegador para completar la incorporación y vuelve a intentarlo.",
+            "unknown": "Se ha producido un error inesperado. Inténtalo de nuevo."
+        },
+        "abort": {
+            "already_in_progress": "Ya hay un proceso de configuración en curso para este dispositivo Quatt.",
+            "already_configured": "El dispositivo ya está configurado.",
+            "no_match": "No se ha encontrado ningún dispositivo Quatt coincidente."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Opciones de Quatt",
+                "data": {
+                    "scan_interval": "Intervalo de actualización local (segundos)",
+                    "remote_scan_interval": "Intervalo de actualización de la API móvil remota (minutos)",
+                    "power_sensor": "Sensor de potencia (opcional)",
+                    "add_remote": "Activar la configuración de conexión remota",
+                    "energy_password": "Contraseña de Quatt Energy"
+                },
+                "data_description": {
+                    "scan_interval": "Número de segundos entre cada solicitud de información a la Quatt.",
+                    "remote_scan_interval": "Número de minutos entre cada solicitud de información a través de la API móvil de Quatt.",
+                    "power_sensor": "Sensor de energía externo que mide el consumo actual de la Quatt.",
+                    "add_remote": "Añadir conectividad remota a través de la API móvil de Quatt para obtener datos adicionales de la bomba de calor.",
+                    "energy_password": "Actualízala solo si has cambiado tu contraseña en mijnenergie.quatt.io."
+                }
+            },
+            "remote": {
+                "description": "Configurar la conexión remota con la bomba de calor Quatt a través de la API móvil.\nIntroduce el ID de CIC (por ejemplo, CIC-xxxx-xxxx-xxxx).",
+                "data": {
+                    "cic": "ID de CIC"
+                }
+            },
+            "auth": {
+                "title": "Iniciar sesión en la API móvil de Quatt",
+                "description": "Introduce tu nombre para crear una cuenta anónima en la API móvil de Quatt. Estos datos solo se almacenan localmente en Home Assistant y se reutilizan para todos los dispositivos Quatt que añadas.",
+                "data": {
+                    "first_name": "Nombre",
+                    "last_name": "Apellidos"
+                }
+            },
+            "pair": {
+                "title": "Emparejar con el dispositivo Quatt",
+                "description": "Pulsa el botón del dispositivo CIC para completar el emparejamiento.\n\n> **{cic}**\n\n![Ubicación del botón de emparejamiento](/quatt_static/pair.png)\nCompleta el emparejamiento en 60 segundos.\n\nPulsa «Enviar» para iniciar el proceso de emparejamiento y espera la confirmación."
+            },
+            "confirm": {
+                "description": "Pulsa «Enviar» para confirmar la configuración."
+            }
+        },
+        "error": {
+            "auth": "Error de autenticación. Comprueba tus credenciales.",
+            "cannot_connect": "No se puede conectar con el CIC local. Comprueba la dirección IP.",
+            "pairing_timeout": "Tiempo de emparejamiento agotado. Inténtalo de nuevo y pulsa el botón del dispositivo CIC en menos de 60 segundos.",
+            "energy_no_ean": "Inicio de sesión correcto, pero no se ha devuelto ningún contador de energía (EAN).",
+            "unknown": "Se ha producido un error inesperado. Inténtalo de nuevo."
+        }
+    }
+}

--- a/custom_components/quatt/translations/fr.json
+++ b/custom_components/quatt/translations/fr.json
@@ -1,0 +1,139 @@
+{
+    "config": {
+        "flow_title": "CIC : {name}",
+        "step": {
+            "user": {
+                "title": "Appareil Quatt",
+                "description": "Quel type d'appareil Quatt souhaitez-vous ajouter ?",
+                "menu_options": {
+                    "local": "Pompe à chaleur (CIC)",
+                    "home_battery": "Batterie domestique",
+                    "energy": "Énergie (mijnenergie)"
+                }
+            },
+            "local": {
+                "description": "Configurer la connexion locale à la pompe à chaleur Quatt.",
+                "data": {
+                    "ip_address": "Adresse IP / nom d'hôte",
+                    "add_remote": "Activer la configuration de la connexion à distance"
+                },
+                "data_description": {
+                    "ip_address": "Sans http:// ni port.",
+                    "add_remote": "Ajouter une connectivité à distance via l'API mobile Quatt pour récupérer des données supplémentaires sur la pompe à chaleur."
+                }
+            },
+            "home_battery": {
+                "title": "Appairer une batterie domestique Quatt",
+                "menu_options": {
+                    "home_battery_qr": "Scanner le code QR",
+                    "home_battery_manual": "Saisir les informations manuellement"
+                }
+            },
+            "home_battery_qr": {
+                "title": "Appairer via code QR",
+                "description": "Scannez le code QR de la batterie et collez l'URL ci-dessous.\n\n![Emplacement de l'étiquette du code QR de la batterie](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_qr_url": "URL du code QR"
+                },
+                "data_description": {
+                    "home_battery_qr_url": "Scannez le code QR et copiez le lien :\n- **iOS** : appui long sur la suggestion QR → Copier le lien\n- **Android** : Google Lens / scan caméra → Copier\n- Toute application de code-barres (ZXing, Binary Eye) affichant le texte brut"
+                }
+            },
+            "home_battery_manual": {
+                "title": "Appairage manuel",
+                "description": "Saisissez l'**UUID**, le **numéro de série** et le **code de vérification** figurant sur l'étiquette de la batterie.\n\n![Emplacement de l'étiquette d'appairage de la batterie](/quatt_static/battery_pair.png)",
+                "data": {
+                    "home_battery_uuid": "UUID",
+                    "home_battery_serial": "Numéro de série",
+                    "home_battery_check_code": "Code de vérification"
+                }
+            },
+            "auth": {
+                "title": "Se connecter à l'API mobile Quatt",
+                "description": "Saisissez votre nom pour créer un compte anonyme sur l'API mobile Quatt. Ces informations sont stockées uniquement localement dans Home Assistant et réutilisées pour tous les appareils Quatt que vous ajoutez.",
+                "data": {
+                    "first_name": "Prénom",
+                    "last_name": "Nom"
+                }
+            },
+            "pair": {
+                "title": "Appairer l'appareil Quatt",
+                "description": "Appuyez sur le bouton de votre appareil CIC pour terminer l'appairage.\n\n> **{cic}**\n\n![Emplacement du bouton d'appairage](/quatt_static/pair.png)\nTerminez l'appairage dans les 60 secondes.\n\nAppuyez sur « Envoyer » pour démarrer le processus d'appairage et attendez la confirmation."
+            },
+            "confirm": {
+                "description": "Appuyez sur « Envoyer » pour confirmer la configuration."
+            },
+            "energy": {
+                "title": "Se connecter à mijnenergie.quatt.io",
+                "description": "Saisissez l'adresse e-mail et le mot de passe que vous utilisez sur {portal_url}. Les identifiants sont stockés uniquement localement dans Home Assistant et utilisés pour maintenir la session active.",
+                "data": {
+                    "energy_username": "Adresse e-mail",
+                    "energy_password": "Mot de passe"
+                }
+            }
+        },
+        "error": {
+            "auth": "Échec de l'authentification. Veuillez vérifier vos identifiants.",
+            "cannot_connect": "Impossible de se connecter au CIC local. Vérifiez l'adresse IP.",
+            "pairing_timeout": "Délai d'appairage dépassé. Veuillez réessayer et appuyer sur le bouton de l'appareil CIC dans les 60 secondes.",
+            "home_battery_qr_invalid": "URL de code QR invalide. Assurez-vous de copier l'URL complète à partir du code QR de la batterie.",
+            "home_battery_pair_failed": "Échec de l'appairage de la batterie domestique. Vérifiez la clé d'accès, le numéro de série et le code de vérification.",
+            "energy_no_ean": "Connexion réussie, mais aucun compteur d'énergie (EAN) n'a été renvoyé. Ouvrez une fois le portail énergie Quatt dans un navigateur pour finaliser l'inscription, puis réessayez.",
+            "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer."
+        },
+        "abort": {
+            "already_in_progress": "Une procédure de configuration est déjà en cours pour cet appareil Quatt.",
+            "already_configured": "L'appareil est déjà configuré.",
+            "no_match": "Aucun appareil Quatt correspondant n'a été trouvé."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Options Quatt",
+                "data": {
+                    "scan_interval": "Intervalle de mise à jour locale (secondes)",
+                    "remote_scan_interval": "Intervalle de mise à jour de l'API mobile distante (minutes)",
+                    "power_sensor": "Capteur de puissance (optionnel)",
+                    "add_remote": "Activer la configuration de la connexion à distance",
+                    "energy_password": "Mot de passe Quatt Energy"
+                },
+                "data_description": {
+                    "scan_interval": "Nombre de secondes entre les demandes d'informations à la Quatt.",
+                    "remote_scan_interval": "Nombre de minutes entre les demandes d'informations via l'API mobile Quatt.",
+                    "power_sensor": "Capteur d'énergie externe qui mesure la consommation actuelle de la Quatt.",
+                    "add_remote": "Ajouter une connectivité à distance via l'API mobile Quatt pour récupérer des données supplémentaires sur la pompe à chaleur.",
+                    "energy_password": "À mettre à jour uniquement si vous avez modifié votre mot de passe sur mijnenergie.quatt.io."
+                }
+            },
+            "remote": {
+                "description": "Configurer la connexion à distance à la pompe à chaleur Quatt via l'API mobile.\nSaisissez l'ID CIC (par exemple, CIC-xxxx-xxxx-xxxx).",
+                "data": {
+                    "cic": "ID CIC"
+                }
+            },
+            "auth": {
+                "title": "Se connecter à l'API mobile Quatt",
+                "description": "Saisissez votre nom pour créer un compte anonyme sur l'API mobile Quatt. Ces informations sont stockées uniquement localement dans Home Assistant et réutilisées pour tous les appareils Quatt que vous ajoutez.",
+                "data": {
+                    "first_name": "Prénom",
+                    "last_name": "Nom"
+                }
+            },
+            "pair": {
+                "title": "Appairer l'appareil Quatt",
+                "description": "Appuyez sur le bouton de votre appareil CIC pour terminer l'appairage.\n\n> **{cic}**\n\n![Emplacement du bouton d'appairage](/quatt_static/pair.png)\nTerminez l'appairage dans les 60 secondes.\n\nAppuyez sur « Envoyer » pour démarrer le processus d'appairage et attendez la confirmation."
+            },
+            "confirm": {
+                "description": "Appuyez sur « Envoyer » pour confirmer la configuration."
+            }
+        },
+        "error": {
+            "auth": "Échec de l'authentification. Veuillez vérifier vos identifiants.",
+            "cannot_connect": "Impossible de se connecter au CIC local. Vérifiez l'adresse IP.",
+            "pairing_timeout": "Délai d'appairage dépassé. Veuillez réessayer et appuyer sur le bouton de l'appareil CIC dans les 60 secondes.",
+            "energy_no_ean": "Connexion réussie, mais aucun compteur d'énergie (EAN) n'a été renvoyé.",
+            "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer."
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `de.json`, `fr.json` and `es.json` under `custom_components/quatt/translations/`
- Each file mirrors the canonical `en.json` structure (config flow + options), so all locales now expose the same keys

## Test plan
- [ ] Restart Home Assistant with the locale set to German, French and Spanish and verify the Quatt config flow / options UI shows the translated strings
- [ ] Confirm no JSON parsing warnings in the Home Assistant log

🤖 Generated with [Claude Code](https://claude.com/claude-code)