### PR TITLE
Refactor local CIC computed value lookup

### DIFF
--- a/custom_components/quatt/binary_sensor.py
+++ b/custom_components/quatt/binary_sensor.py
@@ -62,6 +62,7 @@ def create_heatpump_sensor_entity_descriptions(
         QuattBinarySensorEntityDescription(
             name="Defrost",
             key=f"{prefix}.computedDefrost",
+            computed_key=f"{prefix}.computed_defrost",
             translation_key="hp_silentModeStatus",
             icon="mdi:snowflake",
             quatt_features=QuattFeatureFlags(

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -77,6 +77,13 @@ class QuattDataUpdateCoordinator(DataUpdateCoordinator, ABC):
 
         raise NotImplementedError
 
+    def get_computed_value(
+        self, value_path: str, default: Any | None = None
+    ) -> Any:
+        """Return a computed value if supported by this coordinator."""
+        LOGGER.debug("Computed values are not supported by %s", self.__class__.__name__)
+        return default
+
 
 class QuattCicDataUpdateCoordinator(QuattDataUpdateCoordinator, ABC):
     """Abstract base class for CIC (heatpump) data update coordinators.

--- a/custom_components/quatt/coordinator_local_cic.py
+++ b/custom_components/quatt/coordinator_local_cic.py
@@ -49,13 +49,13 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         )
         return CONVERSION_FACTORS[nearest_temperature]
 
-    def electricalPower(self) -> float | None:  # pylint: disable=invalid-name
+    def electrical_power(self) -> float | None:
         """Get heatpump power from sensor."""
         if self._power_sensor_id is None:
             return None
 
         entity_state = self.hass.states.get(self._power_sensor_id)
-        LOGGER.debug("electricalPower %s", entity_state)
+        LOGGER.debug("electrical_power %s", entity_state)
 
         if entity_state is None:
             return None
@@ -73,7 +73,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
             )
             return None
 
-    def computedWaterDelta(self, parent_key: str | None = None) -> float | None:  # pylint: disable=invalid-name
+    def computed_water_delta(self, parent_key: str | None = None) -> float | None:
         """Compute waterdelta."""
         if parent_key is None:
             parent_key = "" if self.heatpump_2_active() else "hp1"
@@ -86,12 +86,12 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
             temperature_water_in = self.get_value(parent_key + ".temperatureWaterIn")
 
         LOGGER.debug(
-            "%s.computedWaterDelta.temperatureWaterOut %s",
+            "%s.computed_water_delta.temperatureWaterOut %s",
             parent_key,
             temperature_water_out,
         )
         LOGGER.debug(
-            "%s.computedWaterDelta.temperatureWaterIn %s",
+            "%s.computed_water_delta.temperatureWaterIn %s",
             parent_key,
             temperature_water_in,
         )
@@ -101,12 +101,12 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
 
         return round(temperature_water_out - temperature_water_in, 2)
 
-    def computedHeatPower(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_heat_power(self) -> float | None:
         """Compute heatpower."""
 
         # Retrieve the supervisory control mode state first
         state = self.get_value("qc.supervisoryControlMode")
-        LOGGER.debug("computedHeatPower.supervisoryControlMode: %s", state)
+        LOGGER.debug("computed_heat_power.supervisoryControlMode: %s", state)
 
         # If the state is not valid or the heatpump is not active, no need to proceed
         if state is None:
@@ -118,16 +118,18 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
             return 0.0
 
         if self.heatpump_2_active():
-            computed_water_delta = self.computedWaterDelta(None)
+            computed_water_delta = self.computed_water_delta(None)
             temperature_water_out = self.get_value("hp2.temperatureWaterOut")
         else:
-            computed_water_delta = self.computedWaterDelta("hp1")
+            computed_water_delta = self.computed_water_delta("hp1")
             temperature_water_out = self.get_value("hp1.temperatureWaterOut")
         flowrate = self.get_value("qc.flowRateFiltered")
 
-        LOGGER.debug("computedHeatPower.computedWaterDelta %s", computed_water_delta)
-        LOGGER.debug("computedHeatPower.flowRate %s", flowrate)
-        LOGGER.debug("computedHeatPower.temperatureWaterOut %s", temperature_water_out)
+        LOGGER.debug("computed_heat_power.computedWaterDelta %s", computed_water_delta)
+        LOGGER.debug("computed_heat_power.flowRate %s", flowrate)
+        LOGGER.debug(
+            "computed_heat_power.temperatureWaterOut %s", temperature_water_out
+        )
 
         if (
             computed_water_delta is None
@@ -146,7 +148,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         # Prevent any negative numbers
         return max(value, 0.00)
 
-    def computedBoilerHeatPower(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_boiler_heat_power(self) -> float | None:
         """Compute the boiler's added heat power."""
 
         # Check if boiler heating is active
@@ -158,7 +160,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
 
         boiler_active = self.get_value(boiler_active_flag)
         LOGGER.debug(
-            "computedBoilerHeatPower.%s: %s", boiler_active_flag, boiler_active
+            "computed_boiler_heat_power.%s: %s", boiler_active_flag, boiler_active
         )
 
         # If the state is not valid or the boiler is not active, no need to proceed
@@ -178,11 +180,12 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
 
         # Log debug information
         LOGGER.debug(
-            "computedBoilerHeatPower.temperatureWaterOut: %s", heatpump_water_out
+            "computed_boiler_heat_power.temperatureWaterOut: %s", heatpump_water_out
         )
-        LOGGER.debug("computedBoilerHeatPower.flowRate: %s", flowrate)
+        LOGGER.debug("computed_boiler_heat_power.flowRate: %s", flowrate)
         LOGGER.debug(
-            "computedBoilerHeatPower.waterSupplyTemperature: %s", flow_water_temperature
+            "computed_boiler_heat_power.waterSupplyTemperature: %s",
+            flow_water_temperature,
         )
 
         # Validate other inputs
@@ -205,18 +208,18 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         # Prevent any negative numbers
         return max(value, 0.00)
 
-    def computedSystemPower(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_system_power(self) -> float | None:
         """Compute total system power."""
         heater_power = (
             self.get_value("hc.electricalPower")
             if self.all_electric_active()
-            else self.computedBoilerHeatPower()
+            else self.computed_boiler_heat_power()
         )
-        heatpump_power = self.computedPower()
+        heatpump_power = self.computed_power()
 
         # Log debug information
-        LOGGER.debug("computedSystemPower.boilerPower: %s", heater_power)
-        LOGGER.debug("computedSystemPower.heatpumpPower: %s", heatpump_power)
+        LOGGER.debug("computed_system_power.boilerPower: %s", heater_power)
+        LOGGER.debug("computed_system_power.heatpumpPower: %s", heatpump_power)
 
         # Validate inputs
         if heater_power is None or heatpump_power is None:
@@ -224,7 +227,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
 
         return float(heater_power) + float(heatpump_power)
 
-    def computedPowerInput(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_power_input(self) -> float | None:
         """Compute total powerInput."""
         power_input_hp_1 = float(self.get_value("hp1.powerInput", 0))
         power_input_hp_2 = (
@@ -234,7 +237,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         )
         return power_input_hp_1 + power_input_hp_2
 
-    def computedPower(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_power(self) -> float | None:
         """Compute total power."""
         power_hp_1 = float(self.get_value("hp1.power", 0))
         power_hp_2 = (
@@ -242,13 +245,13 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         )
         return power_hp_1 + power_hp_2
 
-    def computedCop(self) -> float | None:  # pylint: disable=invalid-name
+    def computed_cop(self) -> float | None:
         """Compute COP."""
-        electrical_power = self.electricalPower()
-        computed_heat_power = self.computedHeatPower()
+        electrical_power = self.electrical_power()
+        computed_heat_power = self.computed_heat_power()
 
-        LOGGER.debug("computedCop.electricalPower %s", electrical_power)
-        LOGGER.debug("computedCop.computedHeatPower %s", computed_heat_power)
+        LOGGER.debug("computed_cop.electricalPower %s", electrical_power)
+        LOGGER.debug("computed_cop.computedHeatPower %s", computed_heat_power)
 
         if electrical_power is None or computed_heat_power is None:
             return None
@@ -260,17 +263,17 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
 
         return round(computed_heat_power / electrical_power, 2)
 
-    def computedQuattCop(self, parent_key: str | None = None) -> float | None:  # pylint: disable=invalid-name
+    def computed_quatt_cop(self, parent_key: str | None = None) -> float | None:
         """Compute Quatt COP."""
         if parent_key is None:
-            power_input = self.computedPowerInput()
-            power_output = self.computedPower()
+            power_input = self.computed_power_input()
+            power_output = self.computed_power()
         else:
             power_input = self.get_value(parent_key + ".powerInput")
             power_output = self.get_value(parent_key + ".power")
 
-        LOGGER.debug("%s.computedQuattCop.powerInput %s", parent_key, power_input)
-        LOGGER.debug("%s.computedQuattCop.powerOutput %s", parent_key, power_output)
+        LOGGER.debug("%s.computed_quatt_cop.powerInput %s", parent_key, power_input)
+        LOGGER.debug("%s.computed_quatt_cop.powerOutput %s", parent_key, power_output)
 
         if power_input is None or power_output is None:
             return None
@@ -285,7 +288,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         # Prevent negative sign for 0 values (like: -0.0)
         return math.copysign(0.0, 1) if value == 0 else value
 
-    def computedDefrost(self, parent_key: str | None = None) -> bool | None:  # pylint: disable=invalid-name
+    def computed_defrost(self, parent_key: str | None = None) -> bool | None:
         """Compute Quatt Defrost State."""
         if parent_key is None:
             return None
@@ -293,12 +296,12 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         # Get the needed information to determine the defrost case
         state = self.get_value("qc.supervisoryControlMode")
         power_output = self.get_value(f"{parent_key}.power")
-        water_delta = self.computedWaterDelta(parent_key)
+        water_delta = self.computed_water_delta(parent_key)
 
-        LOGGER.debug("%s.computedDefrost.supervisoryControlMode %s", parent_key, state)
-        LOGGER.debug("%s.computedDefrost.powerOutput %s", parent_key, power_output)
+        LOGGER.debug("%s.computed_defrost.supervisoryControlMode %s", parent_key, state)
+        LOGGER.debug("%s.computed_defrost.powerOutput %s", parent_key, power_output)
         LOGGER.debug(
-            "%s.computedDefrost.computedWaterDelta %s", parent_key, water_delta
+            "%s.computed_defrost.computedWaterDelta %s", parent_key, water_delta
         )
 
         if state is None or power_output is None or water_delta is None:
@@ -318,7 +321,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
             and water_delta < -1
         )
 
-    def computedSupervisoryControlMode(self) -> str | None:  # pylint: disable=invalid-name
+    def computed_supervisory_control_mode(self) -> str | None:
         """Map the numeric supervisoryControlMode to a textual status."""
         state = self.get_value("qc.supervisoryControlMode")
         if state is None:
@@ -333,7 +336,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         except ValueError:
             return None
 
-    def computedAllESupervisoryControlMode(self) -> str | None:  # pylint: disable=invalid-name
+    def computed_all_e_supervisory_control_mode(self) -> str | None:
         """Map the numeric All-electric supervisoryControlMode to a textual status."""
         state = self.get_value("qcAllE.allESupervisoryControlMode")
         if state is None:
@@ -344,7 +347,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         except ValueError:
             return None
 
-    def computedElectricityTariffType(self) -> str | None:  # pylint: disable=invalid-name
+    def computed_electricity_tariff_type(self) -> str | None:
         """Map the numeric electricityTariffType to a textual status."""
         state = self.get_value("system.electricityTariffType")
         if state is None:
@@ -355,7 +358,7 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         except ValueError:
             return None
 
-    def computedGasTariffType(self) -> str | None:  # pylint: disable=invalid-name
+    def computed_gas_tariff_type(self) -> str | None:
         """Map the numeric gasTariffType to a textual status."""
         state = self.get_value("system.gasTariffType")
         if state is None:
@@ -366,40 +369,44 @@ class QuattCicLocalDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
         except ValueError:
             return None
 
-    def get_value(self, value_path: str, default: float | None = None) -> Any:
-        """Retrieve a value by dot notation or invoke a computed method."""
+    def get_computed_value(
+        self, value_path: str, default: Any | None = None
+    ) -> Any:
+        """Invoke a computed method by dot notation."""
+        parent_key, _, method_name = value_path.rpartition(".")
+        method = getattr(self, method_name, None)
+
+        if not callable(method):
+            LOGGER.warning("Could not find computed value %s", value_path)
+            return default
+
+        sig = inspect.signature(method)
+        if "parent_key" in sig.parameters:
+            return method(parent_key or None)
+        return method()
+
+    def get_value(self, value_path: str, default: Any | None = None) -> Any:
+        """Retrieve a raw value by dot notation."""
         parts = value_path.split(".")
         current_node = self.data
-        parent_key = None
         for part in parts:
             # Could not find the value, return default
             if current_node is None:
                 return default
 
-            # Computed method invocation
-            if part.startswith("computed") and hasattr(self, part):
-                method = getattr(self, part)
-                sig = inspect.signature(method)
-                # Call with parent_key if accepted, else without
-                if "parent_key" in sig.parameters:
-                    return method(parent_key)
-                return method()
-
             # Dict key access
             if isinstance(current_node, dict) and part in current_node:
                 current_node = current_node[part]
+                continue
 
             # Missing key
-            else:
-                # Ignore any warnings about hp2, boiler and hc
-                # hp2: for single heatpump installations it is valid that hp2 does not exist.
-                # boiler: for all electic installations it is valid that boiler does not exist.
-                # hc: for hybrid installations it is valid that hc does not exist.
-                if part not in ("hp2", "boiler", "hc"):
-                    LOGGER.warning("Could not find %s of %s", part, value_path)
-                    LOGGER.debug(" in %s %s", current_node, type(current_node))
-                return default
-
-            parent_key = part
+            # Ignore any warnings about hp2, boiler and hc
+            # hp2: for single heatpump installations it is valid that hp2 does not exist.
+            # boiler: for all electic installations it is valid that boiler does not exist.
+            # hc: for hybrid installations it is valid that hc does not exist.
+            if part not in ("hp2", "boiler", "hc"):
+                LOGGER.warning("Could not find %s of %s", part, value_path)
+                LOGGER.debug(" in %s %s", current_node, type(current_node))
+            return default
 
         return current_node

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -201,6 +201,15 @@ class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
             return f"chills.{index}"
         return f"chills.{index}.{key_parts[2]}"
 
+    def _get_current_value(
+        self,
+        entity_description: QuattEntityDescriptionMixin,
+    ) -> Any:
+        """Return the entity state from computed or raw coordinator data."""
+        if entity_description.computed_key is not None:
+            return self.coordinator.get_computed_value(entity_description.computed_key)
+        return self.coordinator.get_value(entity_description.raw_value_key)
+
 
 class QuattSensor(QuattEntity, SensorEntity):
     """Quatt Sensor class."""
@@ -233,7 +242,7 @@ class QuattSensor(QuattEntity, SensorEntity):
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the native value of the sensor."""
-        value = self.coordinator.get_value(self.entity_description.key)
+        value = self._get_current_value(self.entity_description)
 
         if value is None:
             return None
@@ -275,7 +284,7 @@ class QuattBinarySensor(QuattEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary_sensor is on."""
-        return self.coordinator.get_value(self.entity_description.key)
+        return self._get_current_value(self.entity_description)
 
 
 class QuattSelect(QuattEntity, SelectEntity):
@@ -309,7 +318,7 @@ class QuattSelect(QuattEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        return self.coordinator.get_value(self.entity_description.key)
+        return self._get_current_value(self.entity_description)
 
     def select_option(self, option: str) -> None:
         """Implement required base class method but do not use it (async handled separately)."""
@@ -383,7 +392,7 @@ class QuattSwitch(QuattEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.coordinator.get_value(self.entity_description.key)
+        return self._get_current_value(self.entity_description)
 
     def turn_on(self, **kwargs) -> None:
         """Implement required base class method but do not use it (async handled separately)."""
@@ -469,12 +478,16 @@ class QuattNumber(QuattEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
-        return self.coordinator.get_value(f"{self.entity_description.key}.value")
+        return self.coordinator.get_value(
+            f"{self.entity_description.raw_value_key}.value"
+        )
 
     @property
     def native_min_value(self) -> float:
         """Return the minimum value."""
-        value = self.coordinator.get_value(f"{self.entity_description.key}.minValue")
+        value = self.coordinator.get_value(
+            f"{self.entity_description.raw_value_key}.minValue"
+        )
         if value is None:
             return super().native_min_value
         return value
@@ -482,7 +495,9 @@ class QuattNumber(QuattEntity, NumberEntity):
     @property
     def native_max_value(self) -> float:
         """Return the maximum value."""
-        value = self.coordinator.get_value(f"{self.entity_description.key}.maxValue")
+        value = self.coordinator.get_value(
+            f"{self.entity_description.raw_value_key}.maxValue"
+        )
         if value is None:
             return super().native_max_value
         return value
@@ -490,7 +505,9 @@ class QuattNumber(QuattEntity, NumberEntity):
     @property
     def native_step(self) -> float | None:
         """Return the step value."""
-        value = self.coordinator.get_value(f"{self.entity_description.key}.increment")
+        value = self.coordinator.get_value(
+            f"{self.entity_description.raw_value_key}.increment"
+        )
         if value is None:
             return super().native_step
         return value
@@ -547,51 +564,84 @@ class QuattFeatureFlags:
     mobile_api: bool = False
 
 
-class QuattSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=True):
+class QuattEntityDescriptionMixin:
+    """Share value lookup key helpers."""
+
+    @property
+    def raw_value_key(self) -> str:
+        """Return the raw coordinator data path, using data_key or key."""
+        return self.data_key or self.key
+
+
+class QuattSensorEntityDescription(
+    QuattEntityDescriptionMixin, SensorEntityDescription, frozen_or_thawed=True
+):
     """A class that describes Quatt sensor entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSensor
     quatt_unique_id_key: str | None = None
 
 
 class QuattBinarySensorEntityDescription(
-    BinarySensorEntityDescription, frozen_or_thawed=True
+    QuattEntityDescriptionMixin,
+    BinarySensorEntityDescription,
+    frozen_or_thawed=True,
 ):
     """A class that describes Quatt binary sensor entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattBinarySensor
     quatt_unique_id_key: str | None = None
 
 
-class QuattSelectEntityDescription(SelectEntityDescription, frozen_or_thawed=True):
+class QuattSelectEntityDescription(
+    QuattEntityDescriptionMixin, SelectEntityDescription, frozen_or_thawed=True
+):
     """A class that describes Quatt select entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSelect
     quatt_unique_id_key: str | None = None
 
 
-class QuattSwitchEntityDescription(SwitchEntityDescription, frozen_or_thawed=True):
+class QuattSwitchEntityDescription(
+    QuattEntityDescriptionMixin, SwitchEntityDescription, frozen_or_thawed=True
+):
     """A class that describes Quatt switch entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSwitch
     quatt_unique_id_key: str | None = None
 
 
-class QuattNumberEntityDescription(NumberEntityDescription, frozen_or_thawed=True):
+class QuattNumberEntityDescription(
+    QuattEntityDescriptionMixin, NumberEntityDescription, frozen_or_thawed=True
+):
     """A class that describes Quatt number entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattNumber
     quatt_unique_id_key: str | None = None
 
 
-class QuattClimateEntityDescription(ClimateEntityDescription, frozen_or_thawed=True):
+class QuattClimateEntityDescription(
+    QuattEntityDescriptionMixin, ClimateEntityDescription, frozen_or_thawed=True
+):
     """A class that describes Quatt climate entities."""
 
+    data_key: str | None = None
+    computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = ClimateEntity
     quatt_unique_id_key: str | None = None

--- a/custom_components/quatt/entity_number.py
+++ b/custom_components/quatt/entity_number.py
@@ -25,7 +25,7 @@ class QuattHomeBatterySolarCapacityNumber(QuattNumber):
     @property
     def native_value(self) -> float | None:
         """Read the scalar value directly from the coordinator data."""
-        return self.coordinator.get_value(self.entity_description.key)
+        return self.coordinator.get_value(self.entity_description.raw_value_key)
 
     @property
     def native_min_value(self) -> float:

--- a/custom_components/quatt/entity_switch.py
+++ b/custom_components/quatt/entity_switch.py
@@ -62,7 +62,7 @@ class QuattEnergyPriceFlagSwitch(QuattSwitch):
         client = self.coordinator.client
         if not isinstance(client, QuattEnergyApiClient):
             return False
-        return bool(getattr(client, self.entity_description.key))
+        return bool(getattr(client, self.entity_description.key, False))
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable the flag."""

--- a/custom_components/quatt/sensor_descriptions_cic.py
+++ b/custom_components/quatt/sensor_descriptions_cic.py
@@ -31,6 +31,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Heat power",
         key="computedHeatPower",
+        computed_key="computed_heat_power",
         icon="mdi:heat-wave",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -40,6 +41,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="COP",
         key="computedCop",
+        computed_key="computed_cop",
         icon="mdi:heat-pump",
         native_unit_of_measurement="CoP",
         suggested_display_precision=2,
@@ -48,6 +50,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Total power input",
         key="computedPowerInput",
+        computed_key="computed_power_input",
         icon="mdi:lightning-bolt",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -57,6 +60,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Total power",
         key="computedPower",
+        computed_key="computed_power",
         icon="mdi:heat-wave",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -66,6 +70,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Total system power",
         key="computedSystemPower",
+        computed_key="computed_system_power",
         icon="mdi:heat-wave",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
@@ -75,6 +80,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Total water delta",
         key="computedWaterDelta",
+        computed_key="computed_water_delta",
         icon="mdi:thermometer-water",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -84,6 +90,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Total Quatt COP",
         key="computedQuattCop",
+        computed_key="computed_quatt_cop",
         icon="mdi:heat-pump",
         native_unit_of_measurement="CoP",
         suggested_display_precision=2,
@@ -96,6 +103,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="QC supervisory control mode",
         key="qc.computedSupervisoryControlMode",
+        computed_key="qc.computed_supervisory_control_mode",
     ),
     QuattSensorEntityDescription(
         name="QC All-Electric supervisory control mode code",
@@ -107,6 +115,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="QC All-Electric supervisory control mode",
         key="qcAllE.computedAllESupervisoryControlMode",
+        computed_key="qcAllE.computed_all_e_supervisory_control_mode",
         quatt_features=QuattFeatureFlags(
             all_electric=True,
         ),
@@ -122,6 +131,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Electricity tariff type",
         key="system.computedElectricityTariffType",
+        computed_key="system.computed_electricity_tariff_type",
         icon="mdi:swap-horizontal-circle",
     ),
     QuattSensorEntityDescription(
@@ -135,6 +145,7 @@ CIC_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Gas tariff type",
         key="system.computedGasTariffType",
+        computed_key="system.computed_gas_tariff_type",
         icon="mdi:swap-horizontal-circle",
     ),
     QuattSensorEntityDescription(
@@ -469,6 +480,7 @@ BOILER_SENSORS: list[QuattSensorEntityDescription] = [
     QuattSensorEntityDescription(
         name="Heat power",
         key="boiler.computedBoilerHeatPower",
+        computed_key="boiler.computed_boiler_heat_power",
         icon="mdi:heat-wave",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,

--- a/custom_components/quatt/sensor_descriptions_heat.py
+++ b/custom_components/quatt/sensor_descriptions_heat.py
@@ -68,6 +68,7 @@ def create_heatpump_sensor_entity_descriptions(
         QuattSensorEntityDescription(
             name="Water delta",
             key=f"{prefix}.computedWaterDelta",
+            computed_key=f"{prefix}.computed_water_delta",
             icon="mdi:thermometer-water",
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
@@ -104,6 +105,7 @@ def create_heatpump_sensor_entity_descriptions(
         QuattSensorEntityDescription(
             name="Quatt COP",
             key=f"{prefix}.computedQuattCop",
+            computed_key=f"{prefix}.computed_quatt_cop",
             icon="mdi:heat-pump",
             native_unit_of_measurement="CoP",
             suggested_display_precision=2,

--- a/tests/components/quatt/test_coordinator_local_cic.py
+++ b/tests/components/quatt/test_coordinator_local_cic.py
@@ -1,0 +1,107 @@
+"""Tests for local CIC coordinator value lookup behaviour."""
+# pylint: disable=import-error,wrong-import-position
+
+from __future__ import annotations
+
+from custom_components.quatt.binary_sensor import (
+    create_heatpump_sensor_entity_descriptions as create_heatpump_binary_sensor_descriptions,
+)
+from custom_components.quatt.coordinator_local_cic import (
+    QuattCicLocalDataUpdateCoordinator,
+)
+from custom_components.quatt.entity import QuattSensor, QuattSensorEntityDescription
+from custom_components.quatt.sensor_descriptions_cic import BOILER_SENSORS, CIC_SENSORS
+from custom_components.quatt.sensor_descriptions_heat import (
+    create_heatpump_sensor_entity_descriptions,
+)
+
+
+def _make_coordinator() -> QuattCicLocalDataUpdateCoordinator:
+    """Create a coordinator instance without calling __init__."""
+    coordinator = object.__new__(QuattCicLocalDataUpdateCoordinator)
+    coordinator.data = {}
+    return coordinator
+
+
+def test_get_value_reads_raw_data_only() -> None:
+    """get_value should read raw API data and not invoke computed methods."""
+    coordinator = _make_coordinator()
+    coordinator.data = {"hp1": {"power": 1200, "powerInput": 400}}
+
+    default = object()
+
+    assert coordinator.get_value("hp1.power") == 1200
+    assert coordinator.get_value("hp1.computed_quatt_cop", default) is default
+
+
+def test_get_computed_value_uses_parent_key_for_heatpump_calculation() -> None:
+    """Computed paths with a parent should pass that parent to the calculation."""
+    coordinator = _make_coordinator()
+    coordinator.data = {
+        "hp1": {
+            "temperatureWaterIn": 30.0,
+            "temperatureWaterOut": 35.5,
+        }
+    }
+
+    assert coordinator.get_computed_value("hp1.computed_water_delta") == 5.5
+
+
+def test_get_computed_value_uses_top_level_calculation() -> None:
+    """Top-level computed paths should call the matching calculation."""
+    coordinator = _make_coordinator()
+    coordinator.data = {
+        "hp1": {"power": 3000, "powerInput": 1000},
+    }
+
+    assert coordinator.get_computed_value("computed_quatt_cop") == 3.0
+
+
+def test_entity_current_value_uses_computed_key() -> None:
+    """Entities should keep legacy keys while reading computed values."""
+    coordinator = _make_coordinator()
+    coordinator.data = {
+        "hp1": {"power": 3000, "powerInput": 1000},
+    }
+    description = QuattSensorEntityDescription(
+        key="computedQuattCop",
+        computed_key="computed_quatt_cop",
+    )
+    sensor = object.__new__(QuattSensor)
+    sensor.coordinator = coordinator
+    sensor.entity_description = description
+
+    assert sensor.native_value == 3.0
+
+
+def test_entity_descriptions_computed_keys_map_to_coordinator_methods() -> None:
+    """All computed keys should resolve to coordinator methods."""
+    coordinator = _make_coordinator()
+
+    descriptions = list(CIC_SENSORS) + list(BOILER_SENSORS)
+    descriptions += create_heatpump_sensor_entity_descriptions(0)
+    descriptions += create_heatpump_sensor_entity_descriptions(1)
+    descriptions += create_heatpump_binary_sensor_descriptions(0)
+    descriptions += create_heatpump_binary_sensor_descriptions(1)
+
+    computed_descriptions = [
+        description
+        for description in descriptions
+        if description.computed_key is not None
+    ]
+
+    assert computed_descriptions, (
+        "No computed keys were found in the entity descriptions"
+    )
+
+    for description in computed_descriptions:
+        computed_key = description.computed_key
+        assert computed_key is not None
+        method_name = computed_key.split(".")[-1]
+        assert hasattr(
+            coordinator,
+            method_name,
+        ), (
+            f"Computed entity key {computed_key} does not map to "
+            f"{method_name} on {coordinator.__class__.__name__}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,11 @@ import pytest_asyncio
 
 from homeassistant.core import HomeAssistant
 
+QUATT_PATH = Path(__file__).resolve().parents[1]
 CORE_PATH = Path(os.environ.get("HA_CORE_PATH", "/workspaces/core"))
 CORE_TESTS_PATH = CORE_PATH / "tests"
+if str(QUATT_PATH) not in sys.path:
+    sys.path.insert(0, str(QUATT_PATH))
 if str(CORE_PATH) not in sys.path:
     sys.path.insert(0, str(CORE_PATH))
 


### PR DESCRIPTION
## Summary

Refactor local CIC value lookup so raw API paths and computed values are resolved separately.

- Keep legacy CamelCase `key` values for stable entity IDs.
- Add explicit `computed_key` values for computed entity descriptions.
- Make `get_value()` raw-data only.
- Add `get_computed_value()` for computed coordinator values.
- Route entity state reads through computed or raw lookup as appropriate.
- Add local CIC coordinator tests for raw lookup, computed lookup, legacy-key entity reads, and computed-key method mapping.
