### PR TITLE
Add night time window controls via remote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Only sensors that are not already provided by the local API are added — no dup
 - **Thermostat data**: Outside temperature (via remote API)
 - **Boiler data** (Hybrid only): Additional boiler power and temperature sensors
 
-In addition, the remote API exposes **programmable day and night maximum sound levels** (normal, library, silent) as controls.
+In addition, the remote API exposes **programmable day and night maximum sound levels** (normal, library, silent) as controls, and the **night time window** (start and end time, in 30-minute steps) as time entities, including a button to reset the window to the Quatt defaults.
 
 ### Enabling
 

--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -64,11 +64,13 @@ from .coordinator_remote_energy import QuattEnergyDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]
 
 # Per-hub stores are always keyed as ``quatt_remote_storage_{unique_id}``.

--- a/custom_components/quatt/api_remote_cic.py
+++ b/custom_components/quatt/api_remote_cic.py
@@ -340,6 +340,39 @@ class QuattCicRemoteApiClient(QuattApiClient):
         _LOGGER.error("CIC settings update failed with status %s", status)
         return False
 
+    async def update_night_window(
+        self,
+        start_hour: int | None,
+        start_minute: int | None,
+        end_hour: int | None,
+        end_minute: int | None,
+    ) -> bool:
+        """Update the CIC night window (30-minute resolution).
+
+        Passing ``None`` for all values resets the window to the Quatt defaults.
+        """
+        if not self._auth.is_authenticated:
+            _LOGGER.error("Cannot update night window: not authenticated")
+            return False
+
+        payload = {
+            "nightTimeStartHour": start_hour,
+            "nightTimeStartMinute": start_minute,
+            "nightTimeEndHour": end_hour,
+            "nightTimeEndMinute": end_minute,
+        }
+        status, _data = await self._auth.request(
+            "PUT",
+            f"/me/cic/{self.cic}/nightWindow",
+            json_body=payload,
+            expected_statuses=(200, 201, 204),
+        )
+        if status in (200, 201, 204):
+            _LOGGER.debug("Night window updated successfully: %s", payload)
+            return True
+        _LOGGER.error("Night window update failed with status %s", status)
+        return False
+
     async def update_chill_action(self, chill_uuid: str, data: dict[str, Any]) -> bool:
         """Update chill device action."""
         if not self._auth.is_authenticated:

--- a/custom_components/quatt/button.py
+++ b/custom_components/quatt/button.py
@@ -1,0 +1,81 @@
+"""Button platform for quatt."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEVICE_BOILER_ID,
+    DEVICE_CIC_ID,
+    DEVICE_FLOWMETER_ID,
+    DEVICE_HEAT_BATTERY_ID,
+    DEVICE_HEAT_CHARGER_ID,
+    DEVICE_HEATPUMP_1_ID,
+    DEVICE_HEATPUMP_2_ID,
+    DEVICE_THERMOSTAT_ID,
+    DOMAIN,
+)
+from .coordinator import QuattDataUpdateCoordinator
+from .entity import (
+    QuattButton,
+    QuattButtonEntityDescription,
+    QuattFeatureFlags,
+)
+from .entity_button import QuattNightWindowResetButton
+from .entity_setup import async_setup_entities
+
+BUTTONS = {
+    # The HUB CIC sensor must be created first to ensure the HUB device is present
+    DEVICE_CIC_ID: [
+        QuattButtonEntityDescription(
+            key="nightWindowReset",
+            name="Reset night time window",
+            icon="mdi:restore",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattNightWindowResetButton,
+        ),
+    ],
+    DEVICE_HEAT_BATTERY_ID: [],
+    DEVICE_HEAT_CHARGER_ID: [],
+    DEVICE_HEATPUMP_1_ID: [],
+    DEVICE_HEATPUMP_2_ID: [],
+    DEVICE_BOILER_ID: [],
+    DEVICE_FLOWMETER_ID: [],
+    DEVICE_THERMOSTAT_ID: [],
+}
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the button platform."""
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+
+    local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
+
+    buttons: list[QuattButton] = []
+    if local_coordinator is not None:
+        buttons += await async_setup_entities(
+            hass=hass,
+            coordinator=local_coordinator,
+            entry=entry,
+            remote=False,
+            entity_descriptions=BUTTONS,
+            entity_domain=BUTTON_DOMAIN,
+        )
+
+    if remote_coordinator:
+        buttons += await async_setup_entities(
+            hass=hass,
+            coordinator=remote_coordinator,
+            entry=entry,
+            remote=True,
+            entity_descriptions=BUTTONS,
+            entity_domain=BUTTON_DOMAIN,
+        )
+
+    async_add_devices(buttons)

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
 from decimal import Decimal
 from enum import Enum
 import logging
@@ -14,6 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
@@ -27,6 +28,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -361,6 +363,144 @@ class QuattSelect(QuattEntity, SelectEntity):
         await self.coordinator.async_request_refresh()
 
 
+class QuattTime(QuattEntity, TimeEntity):
+    """Quatt Time class."""
+
+    def __init__(
+        self,
+        device_name: str,
+        device_id: str,
+        sensor_key: str,
+        coordinator: QuattDataUpdateCoordinator,
+        entity_description: QuattTimeEntityDescription,
+        device_kind: QuattDeviceKind,
+    ) -> None:
+        """Initialize the time class."""
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
+        self.entity_description = entity_description
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Return whether the time entity should be enabled by default."""
+        return self.entity_description.entity_registry_enabled_default
+
+    def set_value(self, value: time) -> None:
+        """Implement required base class method but do not use it (async handled separately)."""
+        raise NotImplementedError("Use async_set_value instead")
+
+    @abstractmethod
+    async def _perform_api_update(self, value: time) -> bool:
+        """Perform the API call to update this setting.
+
+        Must return True if the update succeeded, False otherwise.
+        """
+        raise NotImplementedError
+
+    async def async_set_value(self, value: time) -> None:
+        """Change the time value."""
+        # Only remote coordinator supports updating settings
+        if not isinstance(self.coordinator, QuattCicRemoteDataUpdateCoordinator):
+            _LOGGER.error(
+                "Cannot update %s: only available via remote API",
+                self.entity_description.key,
+            )
+            raise NotImplementedError(
+                f"Setting {self.entity_description.key} is only available via remote API"
+            )
+
+        success = False
+        try:
+            success = await self._perform_api_update(value)
+        except Exception as err:
+            _LOGGER.exception("Error updating %s", self.entity_description.key)
+            raise RuntimeError(
+                f"Failed to update {self.entity_description.key}"
+            ) from err
+
+        if not success:
+            _LOGGER.warning("Failed to update %s", self.entity_description.key)
+            raise RuntimeError(f"Failed to update {self.entity_description.key}")
+
+        # Always refresh coordinator data after a successful update
+        await self.coordinator.async_request_refresh()
+
+
+class QuattButton(QuattEntity, ButtonEntity):
+    """Quatt Button class."""
+
+    def __init__(
+        self,
+        device_name: str,
+        device_id: str,
+        sensor_key: str,
+        coordinator: QuattDataUpdateCoordinator,
+        entity_description: QuattButtonEntityDescription,
+        device_kind: QuattDeviceKind,
+    ) -> None:
+        """Initialize the button class."""
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
+        self.entity_description = entity_description
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Return whether the button should be enabled by default."""
+        return self.entity_description.entity_registry_enabled_default
+
+    def press(self) -> None:
+        """Implement required base class method but do not use it (async handled separately)."""
+        raise NotImplementedError("Use async_press instead")
+
+    @abstractmethod
+    async def _perform_api_update(self) -> bool:
+        """Perform the API call for this button press.
+
+        Must return True if the update succeeded, False otherwise.
+        """
+        raise NotImplementedError
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        # Only remote coordinator supports updating settings
+        if not isinstance(self.coordinator, QuattCicRemoteDataUpdateCoordinator):
+            _LOGGER.error(
+                "Cannot update %s: only available via remote API",
+                self.entity_description.key,
+            )
+            raise NotImplementedError(
+                f"Setting {self.entity_description.key} is only available via remote API"
+            )
+
+        success = False
+        try:
+            success = await self._perform_api_update()
+        except Exception as err:
+            _LOGGER.exception("Error updating %s", self.entity_description.key)
+            raise RuntimeError(
+                f"Failed to update {self.entity_description.key}"
+            ) from err
+
+        if not success:
+            _LOGGER.warning("Failed to update %s", self.entity_description.key)
+            raise RuntimeError(f"Failed to update {self.entity_description.key}")
+
+        # Always refresh coordinator data after a successful update
+        await self.coordinator.async_request_refresh()
+
+
 class QuattSwitch(QuattEntity, SwitchEntity):
     """Quatt Switch class."""
 
@@ -608,6 +748,30 @@ class QuattSelectEntityDescription(
     computed_key: str | None = None
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSelect
+    quatt_unique_id_key: str | None = None
+
+
+class QuattTimeEntityDescription(
+    QuattEntityDescriptionMixin, TimeEntityDescription, frozen_or_thawed=True
+):
+    """A class that describes Quatt time entities."""
+
+    data_key: str | None = None
+    computed_key: str | None = None
+    quatt_features: QuattFeatureFlags = QuattFeatureFlags()
+    quatt_entity_class: type[QuattEntity] = QuattTime
+    quatt_unique_id_key: str | None = None
+
+
+class QuattButtonEntityDescription(
+    QuattEntityDescriptionMixin, ButtonEntityDescription, frozen_or_thawed=True
+):
+    """A class that describes Quatt button entities."""
+
+    data_key: str | None = None
+    computed_key: str | None = None
+    quatt_features: QuattFeatureFlags = QuattFeatureFlags()
+    quatt_entity_class: type[QuattEntity] = QuattButton
     quatt_unique_id_key: str | None = None
 
 

--- a/custom_components/quatt/entity_button.py
+++ b/custom_components/quatt/entity_button.py
@@ -1,0 +1,25 @@
+"""Button entity implementations for Quatt."""
+
+from __future__ import annotations
+
+import logging
+
+from .api_remote_cic import QuattCicRemoteApiClient
+from .entity import QuattButton
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class QuattNightWindowResetButton(QuattButton):
+    """Button that resets the CIC night window to the Quatt defaults."""
+
+    async def _perform_api_update(self) -> bool:
+        """Send null values to the nightWindow endpoint to reset it."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
+            return False
+
+        return await remote_client.update_night_window(None, None, None, None)

--- a/custom_components/quatt/entity_time.py
+++ b/custom_components/quatt/entity_time.py
@@ -1,0 +1,80 @@
+"""Time entity implementations for Quatt."""
+
+from __future__ import annotations
+
+from datetime import time
+import logging
+
+from homeassistant.exceptions import ServiceValidationError
+
+from .api_remote_cic import QuattCicRemoteApiClient
+from .entity import QuattTime
+
+_LOGGER = logging.getLogger(__name__)
+
+# The Quatt nightWindow endpoint only accepts times on 30-minute boundaries.
+NIGHT_WINDOW_MINUTE_STEP = 30
+
+NIGHT_WINDOW_START_KEY = "soundNightTimeStart"
+NIGHT_WINDOW_END_KEY = "soundNightTimeEnd"
+
+
+class QuattNightWindowTime(QuattTime):
+    """Time entity for one boundary (start or end) of the CIC night window.
+
+    The CIC data exposes the boundaries as separate hour/minute fields
+    (``soundNightTimeStartHour``, ``soundNightTimeStartMin``, ...), while the
+    nightWindow endpoint updates both boundaries in a single request.
+    """
+
+    @property
+    def native_value(self) -> time | None:
+        """Combine the hour/minute coordinator values into a time."""
+        hour = self.coordinator.get_value(f"{self.entity_description.key}Hour")
+        if hour is None:
+            return None
+        minute = self.coordinator.get_value(f"{self.entity_description.key}Min")
+        return time(hour=int(hour), minute=int(minute or 0))
+
+    async def async_set_value(self, value: time) -> None:
+        """Validate the 30-minute step before performing the update."""
+        if value.minute % NIGHT_WINDOW_MINUTE_STEP or value.second or value.microsecond:
+            raise ServiceValidationError(
+                f"Night window times must be in {NIGHT_WINDOW_MINUTE_STEP}-minute "
+                "steps (e.g. 21:00 or 21:30)"
+            )
+        await super().async_set_value(value)
+
+    async def _perform_api_update(self, value: time) -> bool:
+        """Send both night window boundaries to the nightWindow endpoint."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
+            return False
+
+        start_hour = self.coordinator.get_value(f"{NIGHT_WINDOW_START_KEY}Hour")
+        start_minute = self.coordinator.get_value(f"{NIGHT_WINDOW_START_KEY}Min")
+        end_hour = self.coordinator.get_value(f"{NIGHT_WINDOW_END_KEY}Hour")
+        end_minute = self.coordinator.get_value(f"{NIGHT_WINDOW_END_KEY}Min")
+
+        if self.entity_description.key == NIGHT_WINDOW_START_KEY:
+            start_hour, start_minute = value.hour, value.minute
+        else:
+            end_hour, end_minute = value.hour, value.minute
+
+        if None in (start_hour, start_minute, end_hour, end_minute):
+            _LOGGER.error(
+                "Cannot update night window: missing current values "
+                "(start=%s:%s, end=%s:%s)",
+                start_hour,
+                start_minute,
+                end_hour,
+                end_minute,
+            )
+            return False
+
+        return await remote_client.update_night_window(
+            int(start_hour), int(start_minute), int(end_hour), int(end_minute)
+        )

--- a/custom_components/quatt/time.py
+++ b/custom_components/quatt/time.py
@@ -1,0 +1,94 @@
+"""Time platform for quatt."""
+
+from __future__ import annotations
+
+from homeassistant.components.time import DOMAIN as TIME_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEVICE_BOILER_ID,
+    DEVICE_CIC_ID,
+    DEVICE_FLOWMETER_ID,
+    DEVICE_HEAT_BATTERY_ID,
+    DEVICE_HEAT_CHARGER_ID,
+    DEVICE_HEATPUMP_1_ID,
+    DEVICE_HEATPUMP_2_ID,
+    DEVICE_THERMOSTAT_ID,
+    DOMAIN,
+)
+from .coordinator import QuattDataUpdateCoordinator
+from .entity import (
+    QuattFeatureFlags,
+    QuattTime,
+    QuattTimeEntityDescription,
+)
+from .entity_setup import async_setup_entities
+from .entity_time import (
+    NIGHT_WINDOW_END_KEY,
+    NIGHT_WINDOW_START_KEY,
+    QuattNightWindowTime,
+)
+
+TIMES = {
+    # The HUB CIC sensor must be created first to ensure the HUB device is present
+    DEVICE_CIC_ID: [
+        QuattTimeEntityDescription(
+            key=NIGHT_WINDOW_START_KEY,
+            name="Night time start",
+            icon="mdi:weather-night",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattNightWindowTime,
+        ),
+        QuattTimeEntityDescription(
+            key=NIGHT_WINDOW_END_KEY,
+            name="Night time end",
+            icon="mdi:weather-sunset-up",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattNightWindowTime,
+        ),
+    ],
+    DEVICE_HEAT_BATTERY_ID: [],
+    DEVICE_HEAT_CHARGER_ID: [],
+    DEVICE_HEATPUMP_1_ID: [],
+    DEVICE_HEATPUMP_2_ID: [],
+    DEVICE_BOILER_ID: [],
+    DEVICE_FLOWMETER_ID: [],
+    DEVICE_THERMOSTAT_ID: [],
+}
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the time platform."""
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+
+    local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
+
+    times: list[QuattTime] = []
+    if local_coordinator is not None:
+        times += await async_setup_entities(
+            hass=hass,
+            coordinator=local_coordinator,
+            entry=entry,
+            remote=False,
+            entity_descriptions=TIMES,
+            entity_domain=TIME_DOMAIN,
+        )
+
+    if remote_coordinator:
+        times += await async_setup_entities(
+            hass=hass,
+            coordinator=remote_coordinator,
+            entry=entry,
+            remote=True,
+            entity_descriptions=TIMES,
+            entity_domain=TIME_DOMAIN,
+        )
+
+    async_add_devices(times)

--- a/tests/components/quatt/test_night_window.py
+++ b/tests/components/quatt/test_night_window.py
@@ -1,0 +1,449 @@
+"""Tests for the CIC night time window controls."""
+# pylint: disable=import-error
+
+from __future__ import annotations
+
+from datetime import time
+from typing import Any
+
+import pytest
+from pytest import MonkeyPatch
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.quatt import entity as quatt_entity
+from custom_components.quatt import entity_button, entity_time
+from custom_components.quatt.api_remote_cic import QuattCicRemoteApiClient
+from custom_components.quatt.button import BUTTONS
+from custom_components.quatt.const import DEVICE_CIC_ID, QuattDeviceKind
+from custom_components.quatt.entity_button import QuattNightWindowResetButton
+from custom_components.quatt.entity_time import (
+    NIGHT_WINDOW_END_KEY,
+    NIGHT_WINDOW_START_KEY,
+    QuattNightWindowTime,
+)
+from custom_components.quatt.time import TIMES
+
+
+class FakeAuth:
+    """Minimal auth client recording requests and replaying queued responses."""
+
+    def __init__(
+        self,
+        responses: list[tuple[int, Any]] | None = None,
+        authenticated: bool = True,
+    ) -> None:
+        """Initialize the fake auth client."""
+        self.requests: list[dict[str, Any]] = []
+        self._responses = list(responses or [])
+        self.is_authenticated = authenticated
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        params: dict[str, Any] | None = None,
+        expected_statuses: tuple[int, ...] = (200, 201, 204),
+        retry_on_auth_error: bool = True,
+    ) -> tuple[int, Any | None]:
+        """Record the request and return the next queued response."""
+        self.requests.append({"method": method, "path": path, "json_body": json_body})
+        if self._responses:
+            return self._responses.pop(0)
+        return (200, {})
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_night_window_sends_both_boundaries() -> None:
+    """Setting the night window should PUT all four values in one request."""
+    auth = FakeAuth(responses=[(204, None)])
+    client = QuattCicRemoteApiClient(cic="CIC-12345678", session=None, auth=auth)
+
+    assert await client.update_night_window(21, 30, 7, 0) is True
+    assert auth.requests == [
+        {
+            "method": "PUT",
+            "path": "/me/cic/CIC-12345678/nightWindow",
+            "json_body": {
+                "nightTimeStartHour": 21,
+                "nightTimeStartMinute": 30,
+                "nightTimeEndHour": 7,
+                "nightTimeEndMinute": 0,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_night_window_reset_sends_nulls() -> None:
+    """Resetting the night window should send null for all values."""
+    auth = FakeAuth(responses=[(200, None)])
+    client = QuattCicRemoteApiClient(cic="CIC-12345678", session=None, auth=auth)
+
+    assert await client.update_night_window(None, None, None, None) is True
+    assert auth.requests[0]["json_body"] == {
+        "nightTimeStartHour": None,
+        "nightTimeStartMinute": None,
+        "nightTimeEndHour": None,
+        "nightTimeEndMinute": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_night_window_reports_failure_status() -> None:
+    """A non-success API status should be reported as failure."""
+    auth = FakeAuth(responses=[(500, None)])
+    client = QuattCicRemoteApiClient(cic="CIC-12345678", session=None, auth=auth)
+
+    assert await client.update_night_window(21, 0, 7, 0) is False
+
+
+@pytest.mark.asyncio
+async def test_update_night_window_requires_authentication() -> None:
+    """Without authentication no request should be made."""
+    auth = FakeAuth(authenticated=False)
+    client = QuattCicRemoteApiClient(cic="CIC-12345678", session=None, auth=auth)
+
+    assert await client.update_night_window(21, 0, 7, 0) is False
+    assert auth.requests == []
+
+
+# ---------------------------------------------------------------------------
+# Entity fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeNightWindowClient:
+    """Minimal remote client recording night window updates."""
+
+    def __init__(self, success: bool = True) -> None:
+        """Initialize the fake remote client."""
+        self.updates: list[tuple[int | None, int | None, int | None, int | None]] = []
+        self._success = success
+
+    async def update_night_window(
+        self,
+        start_hour: int | None,
+        start_minute: int | None,
+        end_hour: int | None,
+        end_minute: int | None,
+    ) -> bool:
+        """Record the night window update and report the configured result."""
+        self.updates.append((start_hour, start_minute, end_hour, end_minute))
+        return self._success
+
+
+class FakeRemoteCoordinator:
+    """Minimal remote coordinator for night window behavior tests."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        data: dict[str, Any],
+        client: FakeNightWindowClient | None = None,
+    ) -> None:
+        """Initialize the fake coordinator."""
+        self.config_entry = config_entry
+        self.data = data
+        self.client = client
+        self.last_update_success = True
+        self.refresh_requests = 0
+
+    def async_add_listener(self, _update_callback) -> Any:
+        """Satisfy CoordinatorEntity construction."""
+        return lambda: None
+
+    def get_value(self, value_path: str, default: Any | None = None) -> Any:
+        """Return a remote API value using Quatt's dot-notation lookup."""
+        parts = value_path.split(".")
+        current_node: Any = self.data
+
+        if isinstance(current_node, dict) and "result" in current_node:
+            current_node = current_node["result"]
+
+        for part in parts:
+            if current_node is None:
+                return default
+            if isinstance(current_node, dict) and part in current_node:
+                current_node = current_node[part]
+                continue
+            return default
+
+        return current_node
+
+    async def async_request_refresh(self) -> None:
+        """Record the refresh request."""
+        self.refresh_requests += 1
+
+
+def _window_data(
+    start_hour: int | None = 21,
+    start_minute: int | None = 0,
+    end_hour: int | None = 7,
+    end_minute: int | None = 0,
+) -> dict[str, Any]:
+    """Return remote API data holding the current night window."""
+    return {
+        "result": {
+            f"{NIGHT_WINDOW_START_KEY}Hour": start_hour,
+            f"{NIGHT_WINDOW_START_KEY}Min": start_minute,
+            f"{NIGHT_WINDOW_END_KEY}Hour": end_hour,
+            f"{NIGHT_WINDOW_END_KEY}Min": end_minute,
+        }
+    }
+
+
+def _time_description(key: str):
+    """Return the time entity description for the given boundary key."""
+    for description in TIMES[DEVICE_CIC_ID]:
+        if description.key == key:
+            return description
+    raise AssertionError(f"No time description for {key}")
+
+
+def _make_time_entity(
+    coordinator: FakeRemoteCoordinator, key: str
+) -> QuattNightWindowTime:
+    """Create a night window time entity on the fake coordinator."""
+    description = _time_description(key)
+    return QuattNightWindowTime(
+        device_name="CIC",
+        device_id=DEVICE_CIC_ID,
+        sensor_key=description.key,
+        coordinator=coordinator,
+        entity_description=description,
+        device_kind=QuattDeviceKind.HUB,
+    )
+
+
+def _make_reset_button(
+    coordinator: FakeRemoteCoordinator,
+) -> QuattNightWindowResetButton:
+    """Create the night window reset button on the fake coordinator."""
+    description = BUTTONS[DEVICE_CIC_ID][0]
+    assert description.key == "nightWindowReset"
+    return QuattNightWindowResetButton(
+        device_name="CIC",
+        device_id=DEVICE_CIC_ID,
+        sensor_key=description.key,
+        coordinator=coordinator,
+        entity_description=description,
+        device_kind=QuattDeviceKind.HUB,
+    )
+
+
+@pytest.fixture(name="remote_classes")
+def remote_classes_fixture(monkeypatch: MonkeyPatch) -> None:
+    """Let the fakes pass the remote coordinator/client isinstance checks."""
+    monkeypatch.setattr(
+        quatt_entity, "QuattCicRemoteDataUpdateCoordinator", FakeRemoteCoordinator
+    )
+    monkeypatch.setattr(entity_time, "QuattCicRemoteApiClient", FakeNightWindowClient)
+    monkeypatch.setattr(entity_button, "QuattCicRemoteApiClient", FakeNightWindowClient)
+
+
+# ---------------------------------------------------------------------------
+# Night window time entities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_time_native_value_combines_hour_and_minute(
+    config_entry: ConfigEntry,
+) -> None:
+    """The time value should combine the separate hour/minute fields."""
+    coordinator = FakeRemoteCoordinator(
+        config_entry, _window_data(start_hour=21, start_minute=30)
+    )
+
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    assert entity.native_value == time(hour=21, minute=30)
+
+
+@pytest.mark.asyncio
+async def test_time_native_value_none_without_hour(
+    config_entry: ConfigEntry,
+) -> None:
+    """Without an hour value the time entity should report unknown."""
+    coordinator = FakeRemoteCoordinator(
+        config_entry, _window_data(start_hour=None, start_minute=None)
+    )
+
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    assert entity.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_time_native_value_defaults_minute_to_zero(
+    config_entry: ConfigEntry,
+) -> None:
+    """A missing minute field should default to zero."""
+    coordinator = FakeRemoteCoordinator(
+        config_entry, _window_data(end_hour=7, end_minute=None)
+    )
+
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_END_KEY)
+
+    assert entity.native_value == time(hour=7, minute=0)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        time(hour=21, minute=15),
+        time(hour=21, minute=1),
+        time(hour=21, minute=0, second=30),
+        time(hour=21, minute=30, microsecond=1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_time_rejects_values_off_the_half_hour(
+    remote_classes: None,
+    config_entry: ConfigEntry,
+    value: time,
+) -> None:
+    """Values not on a 30-minute boundary should be rejected before the API."""
+    client = FakeNightWindowClient()
+    coordinator = FakeRemoteCoordinator(config_entry, _window_data(), client=client)
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    with pytest.raises(ServiceValidationError):
+        await entity.async_set_value(value)
+
+    assert client.updates == []
+    assert coordinator.refresh_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_time_start_updates_start_and_keeps_end(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """Setting the start time should keep the current end boundary."""
+    client = FakeNightWindowClient()
+    coordinator = FakeRemoteCoordinator(
+        config_entry,
+        _window_data(start_hour=21, start_minute=0, end_hour=7, end_minute=30),
+        client=client,
+    )
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    await entity.async_set_value(time(hour=22, minute=30))
+
+    assert client.updates == [(22, 30, 7, 30)]
+    assert coordinator.refresh_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_time_end_updates_end_and_keeps_start(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """Setting the end time should keep the current start boundary."""
+    client = FakeNightWindowClient()
+    coordinator = FakeRemoteCoordinator(
+        config_entry,
+        _window_data(start_hour=21, start_minute=30, end_hour=7, end_minute=0),
+        client=client,
+    )
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_END_KEY)
+
+    await entity.async_set_value(time(hour=6, minute=0))
+
+    assert client.updates == [(21, 30, 6, 0)]
+    assert coordinator.refresh_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_time_fails_without_current_window(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """Without the other boundary's current values the update should fail."""
+    client = FakeNightWindowClient()
+    coordinator = FakeRemoteCoordinator(
+        config_entry,
+        _window_data(end_hour=None, end_minute=None),
+        client=client,
+    )
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    with pytest.raises(RuntimeError):
+        await entity.async_set_value(time(hour=22, minute=0))
+
+    assert client.updates == []
+    assert coordinator.refresh_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_time_raises_on_api_failure(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """A rejected night window update should raise and not request a refresh."""
+    client = FakeNightWindowClient(success=False)
+    coordinator = FakeRemoteCoordinator(config_entry, _window_data(), client=client)
+    entity = _make_time_entity(coordinator, NIGHT_WINDOW_START_KEY)
+
+    with pytest.raises(RuntimeError):
+        await entity.async_set_value(time(hour=22, minute=0))
+
+    assert coordinator.refresh_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Night window reset button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_button_posts_null_window(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """Pressing the reset button should send an all-null window."""
+    client = FakeNightWindowClient()
+    coordinator = FakeRemoteCoordinator(config_entry, _window_data(), client=client)
+    button = _make_reset_button(coordinator)
+
+    await button.async_press()
+
+    assert client.updates == [(None, None, None, None)]
+    assert coordinator.refresh_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_button_raises_on_api_failure(
+    remote_classes: None, config_entry: ConfigEntry
+) -> None:
+    """A rejected reset should raise and not request a refresh."""
+    client = FakeNightWindowClient(success=False)
+    coordinator = FakeRemoteCoordinator(config_entry, _window_data(), client=client)
+    button = _make_reset_button(coordinator)
+
+    with pytest.raises(RuntimeError):
+        await button.async_press()
+
+    assert coordinator.refresh_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Entity descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_night_window_entity_descriptions() -> None:
+    """The CIC device should expose both time entities and the reset button."""
+    time_keys = [description.key for description in TIMES[DEVICE_CIC_ID]]
+    assert time_keys == [NIGHT_WINDOW_START_KEY, NIGHT_WINDOW_END_KEY]
+    for description in TIMES[DEVICE_CIC_ID]:
+        assert description.quatt_features.mobile_api is True
+
+    button = BUTTONS[DEVICE_CIC_ID][0]
+    assert button.key == "nightWindowReset"
+    assert button.quatt_features.mobile_api is True


### PR DESCRIPTION
## Summary

The Quatt mobile API now supports **setting** the CIC night time window (previously read-only) via `PUT /api/v1/me/cic/{cic}/nightWindow`, in 30-minute steps. This PR exposes that as controls on the CIC device:

- **Night time start** / **Night time end** time entities (remote API only). They read the current window from the existing `soundNightTimeStartHour`/`soundNightTimeStartMin` (and End) fields and always send both boundaries in a single request, keeping the other boundary unchanged. Values not on a 30-minute boundary (e.g. 21:15) are rejected with a `ServiceValidationError` so the UI shows a clear message.
- **Reset night time window** button, which posts all-`null` values — the API's documented way to restore the Quatt default window (19:00–07:00).

## Implementation

- New `update_night_window()` method on `QuattCicRemoteApiClient`, accepting `int | None` values so the same method handles both set and reset.
- New `QuattTime` and `QuattButton` base classes in `entity.py`, following the exact pattern of the existing `QuattSelect`/`QuattNumber` setting entities (remote-coordinator gate, abstract `_perform_api_update`, coordinator refresh after success).
- New `time` and `button` platforms (`time.py`, `button.py`) wired through the shared `async_setup_entities` helper, plus `Platform.TIME`/`Platform.BUTTON` in `__init__.py`.
- README updated.

## Testing

- `ruff check` passes on all touched files.
- Verified against a live CIC: setting start/end times via the new entities updates the window (confirmed by the refreshed sensor values), and the reset button restores the Quatt defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
