### PR TITLE
Add heat battery boost support via remote API

### DIFF
--- a/custom_components/quatt/api_remote_cic.py
+++ b/custom_components/quatt/api_remote_cic.py
@@ -235,6 +235,44 @@ class QuattCicRemoteApiClient(QuattApiClient):
                     return chills
         return None
 
+    async def get_all_electric_boost(
+        self, retry_on_403: bool = True
+    ) -> dict[str, Any] | None:
+        """Fetch the all-electric heat battery boost status."""
+        if not self._auth.is_authenticated:
+            return None
+        status, data = await self._auth.request(
+            "GET",
+            f"/me/cic/{self.cic}/allElectricBoost",
+            retry_on_auth_error=retry_on_403,
+        )
+        if status == 200 and isinstance(data, dict):
+            result = data.get("result")
+            if isinstance(result, dict):
+                return result
+        return None
+
+    async def set_all_electric_boost(self, start: bool) -> bool:
+        """Start or cancel the all-electric heat battery boost."""
+        if not self._auth.is_authenticated:
+            _LOGGER.error("Cannot update all-electric boost: not authenticated")
+            return False
+
+        action = "START" if start else "CANCEL"
+        status, _data = await self._auth.request(
+            "POST",
+            f"/me/cic/{self.cic}/allElectricBoost/actions",
+            json_body={"type": action},
+            expected_statuses=(200, 201, 202, 204),
+        )
+        if status in (200, 201, 202, 204):
+            _LOGGER.debug("All-electric boost action %s accepted", action)
+            return True
+        _LOGGER.error(
+            "All-electric boost action %s failed with status %s", action, status
+        )
+        return False
+
     async def async_get_data(self, retry_on_client_error: bool = False) -> Any:
         """Get data for the coordinator (CIC feed + insights)."""
         cic_data = await self.get_cic_data()
@@ -242,6 +280,12 @@ class QuattCicRemoteApiClient(QuattApiClient):
             return None
 
         result = cic_data.get("result", {})
+
+        # Boost status only exists for all-electric installations
+        if result.get("allEStatus"):
+            boost = await self.get_all_electric_boost()
+            if boost is not None:
+                result["allElectricBoost"] = boost
 
         installation_id = self._installation_id or result.get("installationId")
 

--- a/custom_components/quatt/const.py
+++ b/custom_components/quatt/const.py
@@ -279,6 +279,15 @@ REMOTE_MAX_SCAN_INTERVAL: Final = 10
 REMOTE_CONF_SCAN_INTERVAL: Final = "remote_scan_interval"
 INSIGHTS_REMOTE_SCAN_INTERVAL: Final = 60
 
+# All-electric heat battery boost.
+# While a boost is starting/running the remote coordinator polls every
+# BOOST_FAST_SCAN_INTERVAL seconds, and keeps doing so until
+# BOOST_FAST_SCAN_TAIL minutes after the boost ended (completed or canceled),
+# after which it returns to the configured scan interval.
+BOOST_ACTIVE_STATUSES: Final = frozenset({"AWAITING_CIC_STATE", "STARTING", "ACTIVE"})
+BOOST_FAST_SCAN_INTERVAL: Final = 5  # seconds
+BOOST_FAST_SCAN_TAIL: Final = 3  # minutes
+
 
 # Temperature-dependent conversion factors for water in a central heating system at 2 bar pressure.
 # The table below provides specific heat capacity (c_p), density (rho), and conversion factors (k)

--- a/custom_components/quatt/coordinator_remote_cic.py
+++ b/custom_components/quatt/coordinator_remote_cic.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
 
-from .const import LOGGER
+from .api import QuattApiClient
+from .const import (
+    BOOST_ACTIVE_STATUSES,
+    BOOST_FAST_SCAN_INTERVAL,
+    BOOST_FAST_SCAN_TAIL,
+    LOGGER,
+)
 from .coordinator import QuattCicDataUpdateCoordinator
 
 
@@ -14,6 +23,49 @@ class QuattCicRemoteDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
     """Class to manage fetching CIC data from the mobile (remote) API."""
 
     config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        update_interval: timedelta,
+        client: QuattApiClient,
+    ) -> None:
+        """Initialize the remote CIC coordinator."""
+        super().__init__(hass=hass, update_interval=update_interval, client=client)
+        self._configured_update_interval = update_interval
+        self._boost_fast_scan_until: datetime | None = None
+
+    async def _async_update_data(self):
+        """Fetch data and adapt the poll interval to the boost state."""
+        data = await super()._async_update_data()
+        self.update_interval = self._next_update_interval(data)
+        return data
+
+    def _next_update_interval(self, data: Any) -> timedelta:
+        """Return the poll interval matching the current boost state.
+
+        While a boost is starting/active we poll fast so its progress shows up
+        quickly, and we keep polling fast until BOOST_FAST_SCAN_TAIL minutes
+        after the boost was last seen active, so the wind-down after a
+        completion or cancel is picked up too. Outside a boost the configured
+        scan interval applies; a boost started from the Quatt app is then
+        noticed on the next regular poll, which switches to fast polling.
+        """
+        boost = data.get("allElectricBoost") if isinstance(data, dict) else None
+        status = boost.get("status") if isinstance(boost, dict) else None
+
+        now = dt_util.utcnow()
+        if isinstance(status, str) and status.upper() in BOOST_ACTIVE_STATUSES:
+            self._boost_fast_scan_until = now + timedelta(minutes=BOOST_FAST_SCAN_TAIL)
+            return timedelta(seconds=BOOST_FAST_SCAN_INTERVAL)
+
+        if self._boost_fast_scan_until is not None:
+            if now < self._boost_fast_scan_until:
+                return timedelta(seconds=BOOST_FAST_SCAN_INTERVAL)
+            LOGGER.debug("Boost fast polling ended, back to configured scan interval")
+            self._boost_fast_scan_until = None
+
+        return self._configured_update_interval
 
     def get_value(self, value_path: str, default: Any | None = None) -> Any:
         """Retrieve a value by dot notation from the remote API response.

--- a/custom_components/quatt/entity_switch.py
+++ b/custom_components/quatt/entity_switch.py
@@ -6,6 +6,7 @@ import logging
 
 from .api_remote_cic import QuattCicRemoteApiClient
 from .api_remote_energy import QuattEnergyApiClient
+from .const import BOOST_ACTIVE_STATUSES
 from .entity import QuattSwitch
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +44,34 @@ class QuattSettingSwitch(QuattSwitch):
 
         _LOGGER.debug("Updating CIC setting: %s", settings)
         return await remote_client.update_cic_settings(settings)
+
+
+class QuattAllElectricBoostSwitch(QuattSwitch):
+    """Switch entity for the all-electric heat battery boost.
+
+    Turning the switch on starts a boost via the remote API, turning it off
+    cancels the running boost. The state is derived from the boost status
+    polled by the remote coordinator; right after a START the API goes through
+    startup statuses (AWAITING_CIC_STATE, STARTING) before reaching ACTIVE, so
+    all of those count as "on" and can be canceled.
+    """
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if a boost is starting or active."""
+        status = self.coordinator.get_value(self.entity_description.raw_value_key)
+        return isinstance(status, str) and status.upper() in BOOST_ACTIVE_STATUSES
+
+    async def _perform_api_update(self, state: bool) -> bool:
+        """Start (True) or cancel (False) the boost."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
+            return False
+
+        return await remote_client.set_all_electric_boost(state)
 
 
 class QuattEnergyPriceFlagSwitch(QuattSwitch):

--- a/custom_components/quatt/sensor_descriptions_heat.py
+++ b/custom_components/quatt/sensor_descriptions_heat.py
@@ -324,6 +324,36 @@ HEAT_BATTERY_SENSORS: list[QuattSensorEntityDescription] = [
             mobile_api=True,
         ),
     ),
+    QuattSensorEntityDescription(
+        name="Boost status",
+        key="allElectricBoost.status",
+        icon="mdi:rocket-launch",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        quatt_features=QuattFeatureFlags(
+            all_electric=True,
+            mobile_api=True,
+        ),
+    ),
+    QuattSensorEntityDescription(
+        name="Boost end time",
+        key="allElectricBoost.endTime",
+        icon="mdi:clock-end",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        quatt_features=QuattFeatureFlags(
+            all_electric=True,
+            mobile_api=True,
+        ),
+    ),
+    QuattSensorEntityDescription(
+        name="Boost exit reason",
+        key="allElectricBoost.exitReason",
+        icon="mdi:rocket-launch-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        quatt_features=QuattFeatureFlags(
+            all_electric=True,
+            mobile_api=True,
+        ),
+    ),
 ]
 
 

--- a/custom_components/quatt/switch.py
+++ b/custom_components/quatt/switch.py
@@ -27,7 +27,11 @@ from .entity import (
     QuattSwitchEntityDescription,
 )
 from .entity_setup import async_setup_entities
-from .entity_switch import QuattEnergyPriceFlagSwitch, QuattSettingSwitch
+from .entity_switch import (
+    QuattAllElectricBoostSwitch,
+    QuattEnergyPriceFlagSwitch,
+    QuattSettingSwitch,
+)
 
 ENERGY_SWITCHES: list[QuattSwitchEntityDescription] = [
     QuattSwitchEntityDescription(
@@ -72,7 +76,19 @@ SWITCHES = {
             quatt_entity_class=QuattSettingSwitch,
         ),
     ],
-    DEVICE_HEAT_BATTERY_ID: [],
+    DEVICE_HEAT_BATTERY_ID: [
+        QuattSwitchEntityDescription(
+            key="allElectricBoost",
+            data_key="allElectricBoost.status",
+            name="Boost",
+            icon="mdi:rocket-launch",
+            quatt_features=QuattFeatureFlags(
+                all_electric=True,
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattAllElectricBoostSwitch,
+        ),
+    ],
     DEVICE_HEAT_CHARGER_ID: [],
     DEVICE_HEATPUMP_1_ID: [],
     DEVICE_HEATPUMP_2_ID: [],

--- a/tests/components/quatt/test_all_electric_boost.py
+++ b/tests/components/quatt/test_all_electric_boost.py
@@ -1,0 +1,476 @@
+"""Tests for the all-electric heat battery boost feature."""
+# pylint: disable=import-error,protected-access
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from pytest import MonkeyPatch
+
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.quatt import entity as quatt_entity
+from custom_components.quatt import entity_switch
+from custom_components.quatt.api_remote_cic import QuattCicRemoteApiClient
+from custom_components.quatt.const import (
+    BOOST_FAST_SCAN_INTERVAL,
+    BOOST_FAST_SCAN_TAIL,
+    DEVICE_HEAT_BATTERY_ID,
+    QuattDeviceKind,
+)
+from custom_components.quatt.coordinator_remote_cic import (
+    QuattCicRemoteDataUpdateCoordinator,
+)
+from custom_components.quatt.entity_switch import QuattAllElectricBoostSwitch
+from custom_components.quatt.sensor_descriptions_heat import HEAT_BATTERY_SENSORS
+from custom_components.quatt.switch import SWITCHES
+
+CONFIGURED_INTERVAL = timedelta(minutes=1)
+FAST_INTERVAL = timedelta(seconds=BOOST_FAST_SCAN_INTERVAL)
+NOW = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)  # noqa: UP017
+
+
+class FakeAuth:
+    """Minimal auth client recording requests and replaying queued responses."""
+
+    def __init__(
+        self,
+        responses: list[tuple[int, Any]] | None = None,
+        authenticated: bool = True,
+    ) -> None:
+        """Initialize the fake auth client."""
+        self.requests: list[dict[str, Any]] = []
+        self._responses = list(responses or [])
+        self.is_authenticated = authenticated
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        params: dict[str, Any] | None = None,
+        expected_statuses: tuple[int, ...] = (200, 201, 204),
+        retry_on_auth_error: bool = True,
+    ) -> tuple[int, Any | None]:
+        """Record the request and return the next queued response."""
+        self.requests.append({"method": method, "path": path, "json_body": json_body})
+        if self._responses:
+            return self._responses.pop(0)
+        return (200, {})
+
+
+def _make_client(auth: FakeAuth) -> QuattCicRemoteApiClient:
+    """Create a remote API client backed by the fake auth client."""
+    return QuattCicRemoteApiClient(cic="CIC-12345678", session=None, auth=auth)
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_boost_start_posts_start_action() -> None:
+    """Starting the boost should POST a START action to the boost endpoint."""
+    auth = FakeAuth(responses=[(202, None)])
+    client = _make_client(auth)
+
+    assert await client.set_all_electric_boost(True) is True
+    assert auth.requests == [
+        {
+            "method": "POST",
+            "path": "/me/cic/CIC-12345678/allElectricBoost/actions",
+            "json_body": {"type": "START"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_boost_cancel_posts_cancel_action() -> None:
+    """Canceling the boost should POST a CANCEL action."""
+    auth = FakeAuth(responses=[(200, None)])
+    client = _make_client(auth)
+
+    assert await client.set_all_electric_boost(False) is True
+    assert auth.requests[0]["json_body"] == {"type": "CANCEL"}
+
+
+@pytest.mark.asyncio
+async def test_set_boost_reports_failure_status() -> None:
+    """A non-success API status should be reported as failure."""
+    auth = FakeAuth(responses=[(500, None)])
+    client = _make_client(auth)
+
+    assert await client.set_all_electric_boost(True) is False
+
+
+@pytest.mark.asyncio
+async def test_set_boost_requires_authentication() -> None:
+    """Without authentication no request should be made."""
+    auth = FakeAuth(authenticated=False)
+    client = _make_client(auth)
+
+    assert await client.set_all_electric_boost(True) is False
+    assert auth.requests == []
+
+
+@pytest.mark.asyncio
+async def test_get_boost_returns_result() -> None:
+    """The boost status fetch should unwrap the result payload."""
+    boost = {"status": "ACTIVE", "endTime": "2026-08-21T14:00:00Z"}
+    auth = FakeAuth(responses=[(200, {"result": boost})])
+    client = _make_client(auth)
+
+    assert await client.get_all_electric_boost() == boost
+    assert auth.requests[0]["method"] == "GET"
+    assert auth.requests[0]["path"] == "/me/cic/CIC-12345678/allElectricBoost"
+
+
+@pytest.mark.asyncio
+async def test_get_boost_returns_none_on_error() -> None:
+    """A failed boost status fetch should return None."""
+    auth = FakeAuth(responses=[(503, None)])
+    client = _make_client(auth)
+
+    assert await client.get_all_electric_boost() is None
+
+
+@pytest.mark.asyncio
+async def test_async_get_data_includes_boost_for_all_electric() -> None:
+    """All-electric installations should get the boost status merged in."""
+    boost = {"status": "STARTING"}
+    auth = FakeAuth(
+        responses=[
+            (200, {"result": {"allEStatus": True}}),
+            (200, {"result": boost}),
+        ]
+    )
+    client = _make_client(auth)
+
+    data = await client.async_get_data()
+
+    assert data["allElectricBoost"] == boost
+    assert [request["path"] for request in auth.requests] == [
+        "/me/cic/CIC-12345678",
+        "/me/cic/CIC-12345678/allElectricBoost",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_get_data_skips_boost_for_hybrid() -> None:
+    """Non-all-electric installations should not fetch the boost status."""
+    auth = FakeAuth(responses=[(200, {"result": {"allEStatus": False}})])
+    client = _make_client(auth)
+
+    data = await client.async_get_data()
+
+    assert "allElectricBoost" not in data
+    assert [request["path"] for request in auth.requests] == ["/me/cic/CIC-12345678"]
+
+
+@pytest.mark.asyncio
+async def test_async_get_data_survives_boost_fetch_failure() -> None:
+    """A failed boost fetch should not fail the whole coordinator update."""
+    auth = FakeAuth(
+        responses=[
+            (200, {"result": {"allEStatus": True, "hpStatus": 2}}),
+            (503, None),
+        ]
+    )
+    client = _make_client(auth)
+
+    data = await client.async_get_data()
+
+    assert data["hpStatus"] == 2
+    assert "allElectricBoost" not in data
+
+
+# ---------------------------------------------------------------------------
+# Coordinator adaptive polling
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(
+    fast_scan_until: datetime | None = None,
+) -> QuattCicRemoteDataUpdateCoordinator:
+    """Create a remote coordinator instance without calling __init__."""
+    coordinator = object.__new__(QuattCicRemoteDataUpdateCoordinator)
+    coordinator._configured_update_interval = CONFIGURED_INTERVAL
+    coordinator._boost_fast_scan_until = fast_scan_until
+    return coordinator
+
+
+@pytest.fixture(name="frozen_now")
+def frozen_now_fixture(monkeypatch: MonkeyPatch) -> datetime:
+    """Freeze the coordinator's clock at NOW."""
+    from custom_components.quatt import coordinator_remote_cic
+
+    monkeypatch.setattr(coordinator_remote_cic.dt_util, "utcnow", lambda: NOW)
+    return NOW
+
+
+@pytest.mark.parametrize(
+    "status", ["AWAITING_CIC_STATE", "STARTING", "ACTIVE", "active"]
+)
+def test_active_boost_switches_to_fast_polling(
+    frozen_now: datetime, status: str
+) -> None:
+    """Any starting/active boost status should trigger fast polling."""
+    coordinator = _make_coordinator()
+
+    interval = coordinator._next_update_interval(
+        {"allElectricBoost": {"status": status}}
+    )
+
+    assert interval == FAST_INTERVAL
+    assert coordinator._boost_fast_scan_until == NOW + timedelta(
+        minutes=BOOST_FAST_SCAN_TAIL
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"allElectricBoost": None},
+        {"allElectricBoost": {}},
+        {"allElectricBoost": {"status": "FINISHED"}},
+        {"allElectricBoost": {"status": 5}},
+    ],
+)
+def test_no_boost_keeps_configured_interval(frozen_now: datetime, data: Any) -> None:
+    """Without an active boost the configured scan interval applies."""
+    coordinator = _make_coordinator()
+
+    assert coordinator._next_update_interval(data) == CONFIGURED_INTERVAL
+    assert coordinator._boost_fast_scan_until is None
+
+
+def test_fast_polling_continues_during_tail(frozen_now: datetime) -> None:
+    """After the boost ended, fast polling should continue during the tail."""
+    coordinator = _make_coordinator(fast_scan_until=NOW + timedelta(seconds=1))
+
+    interval = coordinator._next_update_interval(
+        {"allElectricBoost": {"status": "FINISHED"}}
+    )
+
+    assert interval == FAST_INTERVAL
+    assert coordinator._boost_fast_scan_until is not None
+
+
+def test_fast_polling_ends_after_tail(frozen_now: datetime) -> None:
+    """Once the tail has passed, polling should return to the configured interval."""
+    coordinator = _make_coordinator(fast_scan_until=NOW - timedelta(seconds=1))
+
+    interval = coordinator._next_update_interval(
+        {"allElectricBoost": {"status": "FINISHED"}}
+    )
+
+    assert interval == CONFIGURED_INTERVAL
+    assert coordinator._boost_fast_scan_until is None
+
+
+def test_boost_seen_active_extends_tail(frozen_now: datetime) -> None:
+    """Every poll that sees an active boost should push the tail forward."""
+    coordinator = _make_coordinator(fast_scan_until=NOW - timedelta(minutes=10))
+
+    interval = coordinator._next_update_interval(
+        {"allElectricBoost": {"status": "ACTIVE"}}
+    )
+
+    assert interval == FAST_INTERVAL
+    assert coordinator._boost_fast_scan_until == NOW + timedelta(
+        minutes=BOOST_FAST_SCAN_TAIL
+    )
+
+
+# ---------------------------------------------------------------------------
+# Boost switch entity
+# ---------------------------------------------------------------------------
+
+
+class FakeBoostClient:
+    """Minimal remote client recording boost actions."""
+
+    def __init__(self, success: bool = True) -> None:
+        """Initialize the fake remote client."""
+        self.actions: list[bool] = []
+        self._success = success
+
+    async def set_all_electric_boost(self, start: bool) -> bool:
+        """Record the boost action and report the configured result."""
+        self.actions.append(start)
+        return self._success
+
+
+class FakeRemoteCoordinator:
+    """Minimal remote coordinator for boost switch behavior tests."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        data: dict[str, Any],
+        client: FakeBoostClient | None = None,
+    ) -> None:
+        """Initialize the fake coordinator."""
+        self.config_entry = config_entry
+        self.data = data
+        self.client = client
+        self.last_update_success = True
+        self.refresh_requests = 0
+
+    def async_add_listener(self, _update_callback) -> Any:
+        """Satisfy CoordinatorEntity construction."""
+        return lambda: None
+
+    def get_value(self, value_path: str, default: Any | None = None) -> Any:
+        """Return a remote API value using Quatt's dot-notation lookup."""
+        parts = value_path.split(".")
+        current_node: Any = self.data
+
+        if isinstance(current_node, dict) and "result" in current_node:
+            current_node = current_node["result"]
+
+        for part in parts:
+            if current_node is None:
+                return default
+            if isinstance(current_node, dict) and part in current_node:
+                current_node = current_node[part]
+                continue
+            return default
+
+        return current_node
+
+    async def async_request_refresh(self) -> None:
+        """Record the refresh request."""
+        self.refresh_requests += 1
+
+
+def _boost_switch_description():
+    """Return the boost switch entity description."""
+    description = SWITCHES[DEVICE_HEAT_BATTERY_ID][0]
+    assert description.key == "allElectricBoost"
+    return description
+
+
+def _make_switch(coordinator: FakeRemoteCoordinator) -> QuattAllElectricBoostSwitch:
+    """Create a boost switch entity on the fake coordinator."""
+    description = _boost_switch_description()
+    return QuattAllElectricBoostSwitch(
+        device_name="Heat battery",
+        device_id=DEVICE_HEAT_BATTERY_ID,
+        sensor_key=description.key,
+        coordinator=coordinator,
+        entity_description=description,
+        device_kind=QuattDeviceKind.DEVICE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("AWAITING_CIC_STATE", True),
+        ("STARTING", True),
+        ("ACTIVE", True),
+        ("active", True),
+        ("FINISHED", False),
+        ("USER_CANCELED", False),
+        (None, False),
+        (5, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_boost_switch_is_on_follows_status(
+    config_entry: ConfigEntry, status: Any, expected: bool
+) -> None:
+    """The switch should be on for starting and active boost statuses."""
+    coordinator = FakeRemoteCoordinator(
+        config_entry, {"result": {"allElectricBoost": {"status": status}}}
+    )
+    switch = _make_switch(coordinator)
+
+    assert switch.is_on is expected
+
+
+@pytest.mark.parametrize(
+    ("turn_on", "expected_action"),
+    [(True, True), (False, False)],
+)
+@pytest.mark.asyncio
+async def test_boost_switch_sends_boost_action(
+    monkeypatch: MonkeyPatch,
+    config_entry: ConfigEntry,
+    turn_on: bool,
+    expected_action: bool,
+) -> None:
+    """Turning the switch on/off should send the matching boost action."""
+    monkeypatch.setattr(
+        quatt_entity, "QuattCicRemoteDataUpdateCoordinator", FakeRemoteCoordinator
+    )
+    monkeypatch.setattr(entity_switch, "QuattCicRemoteApiClient", FakeBoostClient)
+    client = FakeBoostClient()
+    coordinator = FakeRemoteCoordinator(
+        config_entry,
+        {"result": {"allElectricBoost": {"status": "FINISHED"}}},
+        client=client,
+    )
+    switch = _make_switch(coordinator)
+
+    if turn_on:
+        await switch.async_turn_on()
+    else:
+        await switch.async_turn_off()
+
+    assert client.actions == [expected_action]
+    assert coordinator.refresh_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_boost_switch_raises_on_api_failure(
+    monkeypatch: MonkeyPatch, config_entry: ConfigEntry
+) -> None:
+    """A rejected boost action should raise and not request a refresh."""
+    monkeypatch.setattr(
+        quatt_entity, "QuattCicRemoteDataUpdateCoordinator", FakeRemoteCoordinator
+    )
+    monkeypatch.setattr(entity_switch, "QuattCicRemoteApiClient", FakeBoostClient)
+    client = FakeBoostClient(success=False)
+    coordinator = FakeRemoteCoordinator(
+        config_entry,
+        {"result": {"allElectricBoost": {"status": "FINISHED"}}},
+        client=client,
+    )
+    switch = _make_switch(coordinator)
+
+    with pytest.raises(RuntimeError):
+        await switch.async_turn_on()
+
+    assert coordinator.refresh_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Sensor descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_heat_battery_boost_sensor_descriptions() -> None:
+    """The heat battery should expose the boost sensors for all-electric setups."""
+    by_key = {description.key: description for description in HEAT_BATTERY_SENSORS}
+
+    for key in (
+        "allElectricBoost.status",
+        "allElectricBoost.endTime",
+        "allElectricBoost.exitReason",
+    ):
+        description = by_key[key]
+        assert description.quatt_features.all_electric is True
+        assert description.quatt_features.mobile_api is True
+
+    assert by_key["allElectricBoost.endTime"].device_class == (
+        SensorDeviceClass.TIMESTAMP
+    )


### PR DESCRIPTION
## Summary
Adds start/cancel control and progress tracking for the all-electric heat battery boost, using the mobile API `allElectricBoost` endpoints.

- **Boost switch** on the heat battery device (remote API, all-electric only): turning it on POSTs a `START` action, turning it off POSTs `CANCEL`. Startup statuses (`AWAITING_CIC_STATE`, `STARTING`) already count as on, so a boost that is still spinning up can be canceled.
- **Sensors** on the heat battery device: boost status (diagnostic), boost end time (timestamp), and boost exit reason (diagnostic, e.g. `USER_CANCELED`).
- **Data fetch**: the remote coordinator now includes the boost status in every poll, but only for all-electric installations (`allEStatus` present). A failed boost fetch never fails the whole update.
- **Adaptive polling**: while a boost is starting/active the remote coordinator polls every 5 seconds so progress shows up quickly, keeps polling fast until 3 minutes after the boost ended (to catch the exit reason and post-boost charging state), then falls back to the configured scan interval (default 1 minute). A boost started from the Quatt app is noticed on the next regular poll, which then switches to fast polling automatically.

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] Verify on a live all-electric installation: start boost from HA, observe 5s updates through `AWAITING_CIC_STATE` → `STARTING` → `ACTIVE`, cancel from HA, confirm exit reason arrives and polling returns to the configured interval after ~3 minutes
- [x] Start a boost from the Quatt app and confirm HA picks it up within one regular poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)