### PR TITLE
Add missing Quatt All Electric Supervisory Control Modes

### DIFF
--- a/custom_components/quatt/const.py
+++ b/custom_components/quatt/const.py
@@ -213,6 +213,9 @@ class AllElectricSupervisoryControlMode(IntEnum):
     STICKY_PUMP_PROTECTION = 10
     PRE_POST_PUMP_TO_CHARGING = 11
     PRE_POST_PUMP_TO_DISCHARGING = 12
+    CHARGE_CHILL_COOLING = 13
+    CHARGE_DYNAMIC_PRICES = 14
+    CHARGE_DYNAMIC_PRICES_CH_BACKUP = 15
 
     @property
     def description(self) -> str:
@@ -227,10 +230,13 @@ class AllElectricSupervisoryControlMode(IntEnum):
             self.CHARGE_CH_BACKUP: "Charge - CH backup",
             self.CH_BACKUP: "CH backup",
             self.DISCHARGE: "Discharge",
-            self.DISCHARGE_CH_BACKUP: "Discharge CH backup",
+            self.DISCHARGE_CH_BACKUP: "Discharge - CH backup",
             self.STICKY_PUMP_PROTECTION: "Sticky pump protection",
             self.PRE_POST_PUMP_TO_CHARGING: "Pre/post pump to charging",
             self.PRE_POST_PUMP_TO_DISCHARGING: "Pre/post pump to discharging",
+            self.CHARGE_CHILL_COOLING: "Charge - chill cooling",
+            self.CHARGE_DYNAMIC_PRICES: "Charge - dynamic prices",
+            self.CHARGE_DYNAMIC_PRICES_CH_BACKUP: "Charge - dynamic prices CH backup",
         }[self]
 
 

--- a/tests/components/quatt/test_computed_values_local.py
+++ b/tests/components/quatt/test_computed_values_local.py
@@ -414,7 +414,15 @@ def test_computed_supervisory_control_mode(
 
 @pytest.mark.parametrize(
     ("mode", "expected"),
-    [(0, "Idle"), (8, "Discharge"), (99, None)],
+    [
+        (0, "Idle"),
+        (8, "Discharge"),
+        (9, "Discharge - CH backup"),
+        (13, "Charge - chill cooling"),
+        (14, "Charge - dynamic prices"),
+        (15, "Charge - dynamic prices CH backup"),
+        (99, None),
+    ],
 )
 def test_computed_all_e_supervisory_control_mode(
     duo_all_electric_data, mode, expected


### PR DESCRIPTION
The following All Electric Supervisory Control Mode codes were missing:

- "Charge - chill cooling",
- "Charge - dynamic prices",
- "Charge - dynamic prices CH backup",