### PR TITLE
Fix deprecated via_device usage with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This integration covers the **local CIC JSON API** (heat pump telemetry) plus a 
 
 ## Installation
 
+Requires Home Assistant **2025.5.0** or newer.
+
 ### Install with HACS (recommended)
 
 Do you have [HACS](https://hacs.xyz/) installed?

--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -616,6 +616,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 LOGGER.error("Failed to authenticate with Quatt remote API")
                 async_create_remote_auth_issue(hass, entry)
 
+    hub_identifier = (entry.unique_id or entry.entry_id).strip()
+    hub_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, hub_identifier)},
+    )
+    for coordinator in coordinators.values():
+        if coordinator is not None:
+            coordinator.hub_device_id = hub_device.id
+
     # Store coordinators
     hass.data[DOMAIN][entry.entry_id] = coordinators
 

--- a/custom_components/quatt/coordinator.py
+++ b/custom_components/quatt/coordinator.py
@@ -31,6 +31,9 @@ from .const import CONF_POWER_SENSOR, DOMAIN, LOGGER
 class QuattDataUpdateCoordinator(DataUpdateCoordinator, ABC):
     """Product-neutral abstract base class for Quatt data update coordinators."""
 
+    # Assigned during config entry setup before any platform creates entities.
+    hub_device_id: str
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/custom_components/quatt/device.py
+++ b/custom_components/quatt/device.py
@@ -1,0 +1,16 @@
+"""Device registry compatibility helpers for Quatt."""
+
+from typing import cast
+
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+
+def hub_link_info(hub_identifier: str, hub_device_id: str) -> DeviceInfo:
+    """Return the hub link supported by this Home Assistant version."""
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 8):
+        return DeviceInfo(via_device_id=hub_device_id)
+
+    return cast(DeviceInfo, {"via_device": (DOMAIN, hub_identifier)})

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -37,6 +37,7 @@ import homeassistant.util.dt as dt_util
 from .const import ATTRIBUTION, DOMAIN, NAME, QuattDeviceKind
 from .coordinator import QuattDataUpdateCoordinator
 from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
+from .device import hub_link_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,11 +175,13 @@ class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
         else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, f"{self._hub_id}:{device_id}")},
-                via_device=(DOMAIN, self._hub_id),
                 name=device_name,
                 manufacturer=NAME,
                 model="—",
                 entry_type=DeviceEntryType.SERVICE if is_service_device else None,
+            )
+            self._attr_device_info.update(
+                hub_link_info(self._hub_id, coordinator.hub_device_id)
             )
 
     def _current_chill_index(self) -> int | None:

--- a/tests/components/quatt/test_all_electric_boost.py
+++ b/tests/components/quatt/test_all_electric_boost.py
@@ -319,6 +319,7 @@ class FakeRemoteCoordinator:
     ) -> None:
         """Initialize the fake coordinator."""
         self.config_entry = config_entry
+        self.hub_device_id = "test-hub-device-id"
         self.data = data
         self.client = client
         self.last_update_success = True

--- a/tests/components/quatt/test_chill_entities.py
+++ b/tests/components/quatt/test_chill_entities.py
@@ -48,6 +48,7 @@ class FakeRemoteCoordinator:
     ) -> None:
         """Initialize the fake coordinator."""
         self.config_entry = config_entry
+        self.hub_device_id = "test-hub-device-id"
         self.data = data
         self.client = client
         self.last_update_success = True

--- a/tests/components/quatt/test_device.py
+++ b/tests/components/quatt/test_device.py
@@ -1,0 +1,230 @@
+"""Tests for Quatt device links and hub registration."""
+
+from collections.abc import Iterator
+from contextlib import ExitStack
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+# tests/conftest.py exposes the core test helpers at runtime.
+from tests.common import MockConfigEntry  # pylint: disable=import-error,no-name-in-module
+
+from custom_components import quatt
+from custom_components.quatt import device
+from custom_components.quatt.const import (
+    CONF_ENERGY_PASSWORD,
+    CONF_ENERGY_USERNAME,
+    CONF_HOME_BATTERY_SERIAL,
+    CONF_LOCAL_CIC,
+    CONF_REMOTE_CIC,
+    DOMAIN,
+    QuattDeviceKind,
+)
+from custom_components.quatt.entity import QuattEntity
+
+
+@pytest.mark.parametrize(
+    ("major", "minor", "expected"),
+    [
+        pytest.param(2025, 5, {"via_device": (DOMAIN, "CIC-test")}, id="minimum"),
+        pytest.param(2026, 7, {"via_device": (DOMAIN, "CIC-test")}, id="last-legacy"),
+        pytest.param(2026, 8, {"via_device_id": "registry-id"}, id="first-modern"),
+        pytest.param(2026, 9, {"via_device_id": "registry-id"}, id="modern"),
+        pytest.param(2027, 1, {"via_device_id": "registry-id"}, id="next-year"),
+        pytest.param(2027, 8, {"via_device_id": "registry-id"}, id="legacy-removed"),
+    ],
+)
+def test_hub_link_info(
+    monkeypatch: MonkeyPatch,
+    major: int,
+    minor: int,
+    expected: dict[str, str | tuple[str, str]],
+) -> None:
+    """Pass exactly the device link parameter supported by the running version."""
+    monkeypatch.setattr(device, "MAJOR_VERSION", major)
+    monkeypatch.setattr(device, "MINOR_VERSION", minor)
+
+    assert device.hub_link_info("CIC-test", "registry-id") == expected
+
+
+@pytest.fixture(name="mock_coordinators")
+def mock_coordinators_fixture(
+    config_entry: MockConfigEntry,
+) -> Iterator[dict[str, MagicMock]]:
+    """Replace API I/O while exercising the real config entry setup."""
+    coordinator_classes = {
+        "cic_local": "QuattCicLocalDataUpdateCoordinator",
+        "cic_remote": "QuattCicRemoteDataUpdateCoordinator",
+        "home_battery": "QuattHomeBatteryDataUpdateCoordinator",
+        "energy": "QuattEnergyDataUpdateCoordinator",
+    }
+    with ExitStack() as stack:
+        coordinators = {}
+        for key, class_name in coordinator_classes.items():
+            coordinator = MagicMock(spec=getattr(quatt, class_name))
+            coordinator.config_entry = config_entry
+            coordinators[key] = coordinator
+            stack.enter_context(
+                patch.object(quatt, class_name, return_value=coordinator)
+            )
+        stack.enter_context(patch.object(quatt.Store, "async_load", return_value={}))
+        stack.enter_context(patch.object(quatt, "async_get_clientsession"))
+        stack.enter_context(patch.object(quatt, "async_create_clientsession"))
+        stack.enter_context(patch.object(quatt, "_get_or_create_auth_client"))
+        stack.enter_context(patch.object(quatt, "_register_services"))
+        remote_client = stack.enter_context(
+            patch.object(quatt, "QuattCicRemoteApiClient")
+        )
+        remote_client.return_value.authenticate = AsyncMock(return_value=True)
+        yield coordinators
+
+
+@dataclass(frozen=True)
+class HubSetup:
+    """Config entry settings and coordinators expected for a hub."""
+
+    entry_data: dict[str, str]
+    unique_id: str | None
+    active_coordinators: tuple[str, ...]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "hub_setup",
+    [
+        pytest.param(
+            HubSetup({CONF_LOCAL_CIC: "192.0.2.1"}, "CIC-test", ("cic_local",)),
+            id="local-cic",
+        ),
+        pytest.param(
+            HubSetup(
+                {CONF_LOCAL_CIC: "192.0.2.1", CONF_REMOTE_CIC: "CIC-test"},
+                "CIC-test",
+                ("cic_local", "cic_remote"),
+            ),
+            id="local-and-remote-cic",
+        ),
+        pytest.param(
+            HubSetup(
+                {CONF_HOME_BATTERY_SERIAL: "battery-test"},
+                "BAT-test",
+                ("home_battery",),
+            ),
+            id="home-battery",
+        ),
+        pytest.param(
+            HubSetup(
+                {
+                    CONF_ENERGY_USERNAME: "test@example.com",
+                    CONF_ENERGY_PASSWORD: "test",
+                },
+                "energy-test",
+                ("energy",),
+            ),
+            id="energy",
+        ),
+        pytest.param(
+            HubSetup({CONF_LOCAL_CIC: "192.0.2.1"}, None, ("cic_local",)),
+            id="entry-id-fallback",
+        ),
+        pytest.param(
+            HubSetup({CONF_LOCAL_CIC: "192.0.2.1"}, " CIC-test ", ("cic_local",)),
+            id="trimmed-id",
+        ),
+    ],
+)
+async def test_hub_registered_before_platforms_and_reused_on_reload(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_coordinators: dict[str, MagicMock],
+    caplog: LogCaptureFixture,
+    hub_setup: HubSetup,
+) -> None:
+    """Fresh setup and reload preserve device IDs, entity IDs and hub metadata."""
+    hass.config_entries.async_update_entry(
+        config_entry, data=hub_setup.entry_data, unique_id=hub_setup.unique_id
+    )
+    registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    hub_identifier = (hub_setup.unique_id or config_entry.entry_id).strip()
+    device_ids: list[str] = []
+    entity_ids: list[str] = []
+    unrelated_entry = MockConfigEntry(domain=DOMAIN, unique_id="CIC-other", data={})
+    unrelated_entry.add_to_hass(hass)
+    unrelated_hub = registry.async_get_or_create(
+        config_entry_id=unrelated_entry.entry_id,
+        identifiers={(DOMAIN, "CIC-other")},
+    )
+
+    async def setup_platforms(entry: ConfigEntry, platforms: list[Platform]) -> None:
+        assert entry is config_entry
+        assert platforms == quatt.PLATFORMS
+        coordinator = hass.data[DOMAIN][entry.entry_id][
+            hub_setup.active_coordinators[0]
+        ]
+        hub = registry.async_get(coordinator.hub_device_id)
+        assert hub is not None
+        assert hub.identifiers == {(DOMAIN, hub_identifier)}
+        assert hub.id != unrelated_hub.id
+        assert hub.via_device_id is None
+        for key in hub_setup.active_coordinators:
+            assert mock_coordinators[key].hub_device_id == hub.id
+        for kind in (
+            QuattDeviceKind.DEVICE,
+            QuattDeviceKind.SERVICE,
+            QuattDeviceKind.HUB,
+        ):
+            entity = QuattEntity(
+                device_name=kind.value,
+                device_id=kind.value,
+                sensor_key="value",
+                coordinator=coordinator,
+                device_kind=kind,
+            )
+            assert entity.unique_id == f"{hub_identifier}:{kind.value}:value"
+            registered_device = registry.async_get_or_create(
+                config_entry_id=entry.entry_id, **entity.device_info
+            )
+            device_ids.append(registered_device.id)
+            registered_entity = entity_registry.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                entity.unique_id,
+                config_entry=entry,
+                device_id=registered_device.id,
+            )
+            entity_ids.append(registered_entity.entity_id)
+        assert registry.async_get(device_ids[-3]).via_device_id == hub.id
+        assert registry.async_get(device_ids[-2]).via_device_id == hub.id
+        assert (
+            registry.async_get(device_ids[-2]).entry_type is dr.DeviceEntryType.SERVICE
+        )
+        assert device_ids[-1] == hub.id
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            side_effect=setup_platforms,
+        ),
+        patch.object(hass.config_entries, "async_unload_platforms", return_value=True),
+    ):
+        assert await quatt.async_setup_entry(hass, config_entry)
+        hub_id = device_ids[-1]
+        registry.async_update_device(hub_id, name_by_user="My Quatt")
+        assert await quatt.async_unload_entry(hass, config_entry)
+        assert await quatt.async_setup_entry(hass, config_entry)
+
+    assert device_ids[:3] == device_ids[3:]
+    assert entity_ids[:3] == entity_ids[3:]
+    assert len(dr.async_entries_for_config_entry(registry, config_entry.entry_id)) == 3
+    assert registry.async_get(hub_id).name_by_user == "My Quatt"
+    assert registry.async_get(hub_id).via_device_id is None
+    assert "deprecated `via_device`" not in caplog.text

--- a/tests/components/quatt/test_entity_setup.py
+++ b/tests/components/quatt/test_entity_setup.py
@@ -21,6 +21,7 @@ from custom_components.quatt.climate import (
     create_chill_climate_entity_descriptions,
 )
 from custom_components.quatt.const import DOMAIN, DEVICE_CIC_ID, QuattDeviceKind
+from custom_components.quatt.device import hub_link_info
 from custom_components.quatt.entity_setup import (
     async_setup_entities,
     create_chill_entity_descriptions,
@@ -130,7 +131,7 @@ async def test_async_setup_entities_removes_obsolete_chill_device(
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
-    device_registry.async_get_or_create(
+    hub_device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, config_entry.unique_id)},
         name="Quatt",
@@ -138,7 +139,7 @@ async def test_async_setup_entities_removes_obsolete_chill_device(
     chill_device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, f"{config_entry.unique_id}:uuid-gone")},
-        via_device=(DOMAIN, config_entry.unique_id),
+        **hub_link_info(config_entry.unique_id, hub_device.id),
         name="Old bedroom",
     )
     entity_registry.async_get_or_create(
@@ -161,12 +162,7 @@ async def test_async_setup_entities_removes_obsolete_chill_device(
     )
 
     assert entities == []
-    assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{config_entry.unique_id}:uuid-gone")}
-        )
-        is None
-    )
+    assert device_registry.async_get(chill_device.id) is None
     assert (
         entity_registry.async_get_entity_id(
             CLIMATE_DOMAIN,

--- a/tests/components/quatt/test_night_window.py
+++ b/tests/components/quatt/test_night_window.py
@@ -152,6 +152,7 @@ class FakeRemoteCoordinator:
     ) -> None:
         """Initialize the fake coordinator."""
         self.config_entry = config_entry
+        self.hub_device_id = "test-hub-device-id"
         self.data = data
         self.client = client
         self.last_update_success = True


### PR DESCRIPTION
Fixes #356.

Quatt passes the deprecated `via_device` parameter through the shared entity class, causing warnings when sensor and binary sensor devices are registered. Register the hub before platform setup and share its registry ID with all coordinators. Use `via_device_id` on Home Assistant 2026.8 and later, retaining `via_device` on older versions so the minimum remains 2025.5.0.

Existing device identifiers and entity unique IDs are preserved. The new regression tests cover version boundaries, hub registration before entity creation, reloads, separate hubs, device and service links, and preservation of registry IDs and user-defined names.

Validation:
- All 12 new regression cases pass; Ruff passes for the repository and pylint passes for the new test file.
- Targeted checks against installed Home Assistant 2025.5.0, 2026.8.0 and 2026.9.0 pass for local CIC, local + remote CIC, Home Battery and Energy setup/reload. These use the real coordinators and registries with API I/O mocked.
- Manually validated on 2026.10.0-dev after a full startup: the warning is absent, Boiler shows “Connected via CIC”, and the water outlet temperature continues updating.
- Full Quatt suite on the latest upstream base: 298 passed, 2 failed. Both failures are outside this change: the supervisory-control test still expects “Cooling” after #355 renamed it to “Chill cooling”; the existing Chill rename test reaches the separately deprecated `async_get_device` call with an uninitialized frame helper.