### PR TITLE
Fix Chill device lookup with backward compatibility and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The Remote Mobile API can be enabled either while adding the CIC for the first t
 
 - **Climate control**: A climate entity for Quatt Chill devices with heating, cooling, target temperature and fan mode control.
 - **Status and diagnostics**: Chill mode, fan mode, ambient temperature, status and update-state sensors.
+- **Device names**: Names from the Quatt app are synchronized on refresh. Names you set manually in Home Assistant remain unchanged.
 
 ## Home battery
 

--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -61,6 +61,7 @@ from .coordinator_home_battery import QuattHomeBatteryDataUpdateCoordinator
 from .coordinator_local_cic import QuattCicLocalDataUpdateCoordinator
 from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
 from .coordinator_remote_energy import QuattEnergyDataUpdateCoordinator
+from .device import async_get_device_by_identifier
 from .repairs import (
     async_create_remote_auth_issue,
     async_delete_remote_auth_issue,
@@ -448,8 +449,8 @@ def _sync_chill_device_names(
         if not chill_uuid or not chill_name:
             continue
 
-        device = device_reg.async_get_device(
-            identifiers={(DOMAIN, f"{hub_id}:{chill_uuid}")}
+        device = async_get_device_by_identifier(
+            device_reg, (DOMAIN, f"{hub_id}:{chill_uuid}"), entry.entry_id
         )
         if device is None or device.name == chill_name:
             continue

--- a/custom_components/quatt/device.py
+++ b/custom_components/quatt/device.py
@@ -3,6 +3,8 @@
 from typing import cast
 
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
@@ -14,3 +16,23 @@ def hub_link_info(hub_identifier: str, hub_device_id: str) -> DeviceInfo:
         return DeviceInfo(via_device_id=hub_device_id)
 
     return cast(DeviceInfo, {"via_device": (DOMAIN, hub_identifier)})
+
+
+@callback
+def async_get_device_by_identifier(
+    registry: dr.DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Look up a device within its config entry across supported HA versions."""
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 8):
+        return registry.async_get_device_by_identifier(identifier, config_entry_id)
+
+    return next(
+        (
+            device
+            for device in dr.async_entries_for_config_entry(registry, config_entry_id)
+            if identifier in device.identifiers
+        ),
+        None,
+    )

--- a/tests/components/quatt/test_all_electric_boost.py
+++ b/tests/components/quatt/test_all_electric_boost.py
@@ -214,7 +214,13 @@ def frozen_now_fixture(monkeypatch: MonkeyPatch) -> datetime:
 
 
 @pytest.mark.parametrize(
-    "status", ["AWAITING_CIC_STATE", "STARTING", "ACTIVE", "active"]
+    "status",
+    [
+        pytest.param("AWAITING_CIC_STATE", id="awaiting-cic-state"),
+        pytest.param("STARTING", id="starting"),
+        pytest.param("ACTIVE", id="active"),
+        pytest.param("active", id="active-lowercase"),
+    ],
 )
 def test_active_boost_switches_to_fast_polling(
     frozen_now: datetime, status: str
@@ -235,12 +241,12 @@ def test_active_boost_switches_to_fast_polling(
 @pytest.mark.parametrize(
     "data",
     [
-        None,
-        {},
-        {"allElectricBoost": None},
-        {"allElectricBoost": {}},
-        {"allElectricBoost": {"status": "FINISHED"}},
-        {"allElectricBoost": {"status": 5}},
+        pytest.param(None, id="no-data"),
+        pytest.param({}, id="missing-boost"),
+        pytest.param({"allElectricBoost": None}, id="null-boost"),
+        pytest.param({"allElectricBoost": {}}, id="empty-boost"),
+        pytest.param({"allElectricBoost": {"status": "FINISHED"}}, id="finished"),
+        pytest.param({"allElectricBoost": {"status": 5}}, id="invalid-status"),
     ],
 )
 def test_no_boost_keeps_configured_interval(frozen_now: datetime, data: Any) -> None:
@@ -375,14 +381,14 @@ def _make_switch(coordinator: FakeRemoteCoordinator) -> QuattAllElectricBoostSwi
 @pytest.mark.parametrize(
     ("status", "expected"),
     [
-        ("AWAITING_CIC_STATE", True),
-        ("STARTING", True),
-        ("ACTIVE", True),
-        ("active", True),
-        ("FINISHED", False),
-        ("USER_CANCELED", False),
-        (None, False),
-        (5, False),
+        pytest.param("AWAITING_CIC_STATE", True, id="awaiting-cic-state"),
+        pytest.param("STARTING", True, id="starting"),
+        pytest.param("ACTIVE", True, id="active"),
+        pytest.param("active", True, id="active-lowercase"),
+        pytest.param("FINISHED", False, id="finished"),
+        pytest.param("USER_CANCELED", False, id="user-canceled"),
+        pytest.param(None, False, id="missing-status"),
+        pytest.param(5, False, id="invalid-status"),
     ],
 )
 @pytest.mark.asyncio
@@ -400,7 +406,10 @@ async def test_boost_switch_is_on_follows_status(
 
 @pytest.mark.parametrize(
     ("turn_on", "expected_action"),
-    [(True, True), (False, False)],
+    [
+        pytest.param(True, True, id="turn-on"),
+        pytest.param(False, False, id="turn-off"),
+    ],
 )
 @pytest.mark.asyncio
 async def test_boost_switch_sends_boost_action(

--- a/tests/components/quatt/test_api_home_battery.py
+++ b/tests/components/quatt/test_api_home_battery.py
@@ -73,8 +73,19 @@ def test_summarize_today_insights_no_optional_fields() -> None:
     assert "latestTimestamp" not in summary
 
 
-@pytest.mark.parametrize("raw", [None, {}, [], "text", 42])
-def test_summarize_today_insights_invalid_input(raw) -> None:
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param(None, id="none"),
+        pytest.param({}, id="empty-dict"),
+        pytest.param([], id="empty-list"),
+        pytest.param("text", id="string"),
+        pytest.param(42, id="number"),
+    ],
+)
+def test_summarize_today_insights_invalid_input(
+    raw: dict[str, object] | list[object] | str | int | None,
+) -> None:
     """Anything but a non-empty list yields None."""
     assert _summarize_today_insights(raw) is None
 
@@ -113,8 +124,16 @@ def test_add_euro_fields() -> None:
     assert "unrelatedEur" not in section
 
 
-@pytest.mark.parametrize("section", [None, "text", 42, ["totalSavedCents"]])
-def test_add_euro_fields_non_dict_noop(section) -> None:
+@pytest.mark.parametrize(
+    "section",
+    [
+        pytest.param(None, id="none"),
+        pytest.param("text", id="string"),
+        pytest.param(42, id="number"),
+        pytest.param(["totalSavedCents"], id="list"),
+    ],
+)
+def test_add_euro_fields_non_dict_noop(section: str | int | list[str] | None) -> None:
     """Non-dict sections are left untouched without raising."""
     _add_euro_fields(section)
 
@@ -141,12 +160,8 @@ def _make_client(
         return value
 
     monkeypatch.setattr(client, "get_status", lambda: _return(status))
-    monkeypatch.setattr(
-        client, "get_savings_overview", lambda: _return(savings)
-    )
-    monkeypatch.setattr(
-        client, "_get_today_insights_cached", lambda: _return(insights)
-    )
+    monkeypatch.setattr(client, "get_savings_overview", lambda: _return(savings))
+    monkeypatch.setattr(client, "_get_today_insights_cached", lambda: _return(insights))
     monkeypatch.setattr(client, "get_installation", lambda: _return(installation))
     monkeypatch.setattr(
         client, "_get_today_energy_flow_cached", lambda: _return(energy_flow)

--- a/tests/components/quatt/test_computed_values_local.py
+++ b/tests/components/quatt/test_computed_values_local.py
@@ -84,15 +84,19 @@ def test_feature_detection_mono_hybrid(duo_all_electric_data: dict) -> None:
 @pytest.mark.parametrize(
     ("temperature", "expected_key"),
     [
-        (40, 40),  # exact match
-        (21.52, 20),  # nearest below midpoint
-        (23.1, 25),  # nearest above midpoint
-        (-10, 5),  # clamped to lowest table entry
-        (150, 80),  # clamped to highest table entry
-        (27.5, 25),  # tie resolves to the first (lower) table entry
+        pytest.param(40, 40, id="exact-match"),
+        pytest.param(21.52, 20, id="nearest-below-midpoint"),
+        pytest.param(23.1, 25, id="nearest-above-midpoint"),
+        pytest.param(-10, 5, id="below-range"),
+        pytest.param(150, 80, id="above-range"),
+        pytest.param(27.5, 25, id="midpoint-prefers-lower"),
     ],
 )
-def test_get_conversion_factor(coordinator, temperature, expected_key) -> None:
+def test_get_conversion_factor(
+    coordinator: QuattCicLocalDataUpdateCoordinator,
+    temperature: float,
+    expected_key: int,
+) -> None:
     """The conversion factor is looked up by nearest table temperature."""
     assert coordinator.get_conversion_factor(temperature) == pytest.approx(
         CONVERSION_FACTORS[expected_key]
@@ -111,9 +115,14 @@ def test_computed_water_delta_duo_spans_both_pumps(coordinator) -> None:
 
 @pytest.mark.parametrize(
     ("parent_key", "expected"),
-    [("hp1", 21.41 - 18.39), ("hp2", 21.52 - 18.09)],
+    [
+        pytest.param("hp1", 21.41 - 18.39, id="heatpump-1"),
+        pytest.param("hp2", 21.52 - 18.09, id="heatpump-2"),
+    ],
 )
-def test_computed_water_delta_per_pump(coordinator, parent_key, expected) -> None:
+def test_computed_water_delta_per_pump(
+    coordinator: QuattCicLocalDataUpdateCoordinator, parent_key: str, expected: float
+) -> None:
     """A parent key computes the delta over that pump only."""
     assert coordinator.computed_water_delta(parent_key) == pytest.approx(expected)
 
@@ -276,9 +285,7 @@ def test_computed_cop_with_power_sensor(duo_all_electric_data) -> None:
     )
 
     heat_power = coordinator.computed_heat_power()
-    assert coordinator.computed_cop() == pytest.approx(
-        round(heat_power / 18.0, 2)
-    )
+    assert coordinator.computed_cop() == pytest.approx(round(heat_power / 18.0, 2))
 
 
 def test_computed_cop_zero_electrical_power(coordinator) -> None:
@@ -290,8 +297,17 @@ def test_computed_cop_zero_electrical_power(coordinator) -> None:
     assert coordinator.computed_cop() is None
 
 
-@pytest.mark.parametrize("state", ["unavailable", "unknown", "not-a-number"])
-def test_electrical_power_invalid_states(coordinator, state) -> None:
+@pytest.mark.parametrize(
+    "state",
+    [
+        pytest.param("unavailable", id="unavailable"),
+        pytest.param("unknown", id="unknown"),
+        pytest.param("not-a-number", id="non-numeric"),
+    ],
+)
+def test_electrical_power_invalid_states(
+    coordinator: QuattCicLocalDataUpdateCoordinator, state: str
+) -> None:
     """Unavailable, unknown and non-numeric sensor states yield None."""
     coordinator._power_sensor_id = "sensor.hp_power"  # noqa: SLF001
     coordinator.hass = SimpleNamespace(
@@ -368,11 +384,13 @@ def test_computed_defrost_detected(duo_all_electric_data) -> None:
 @pytest.mark.parametrize(
     ("power", "water_out"),
     [
-        (-0.5, 22.0),  # power dip too small
-        (-500, 24.5),  # delta not negative enough
+        pytest.param(-0.5, 22.0, id="power-dip-too-small"),
+        pytest.param(-500, 24.5, id="temperature-delta-too-small"),
     ],
 )
-def test_computed_defrost_boundaries(duo_all_electric_data, power, water_out) -> None:
+def test_computed_defrost_boundaries(
+    duo_all_electric_data: dict[str, Any], power: float, water_out: float
+) -> None:
     """Both the power and the delta threshold must be crossed."""
     data = deepcopy(duo_all_electric_data)
     data["qc"]["supervisoryControlMode"] = int(
@@ -393,17 +411,19 @@ def test_computed_defrost_boundaries(duo_all_electric_data, power, water_out) ->
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [
-        (0, "Standby"),
-        (2, "Heating - heatpump only"),
-        (6, "Cooling"),
-        (96, "Anti-freeze protection - boiler on"),
-        (100, "Commissioning modes"),
-        (245, "Commissioning modes"),
-        (42, None),  # unknown code below 100
+        pytest.param(0, "Standby", id="standby"),
+        pytest.param(2, "Heating - heatpump only", id="heating-heatpump-only"),
+        pytest.param(6, "Chill cooling", id="chill-cooling"),
+        pytest.param(
+            96, "Anti-freeze protection - boiler on", id="anti-freeze-boiler-on"
+        ),
+        pytest.param(100, "Commissioning modes", id="commissioning-100"),
+        pytest.param(245, "Commissioning modes", id="commissioning-245"),
+        pytest.param(42, None, id="unknown-mode"),
     ],
 )
 def test_computed_supervisory_control_mode(
-    duo_all_electric_data, mode, expected
+    duo_all_electric_data: dict[str, Any], mode: int, expected: str | None
 ) -> None:
     """Numeric supervisory control modes map to their descriptions."""
     data = deepcopy(duo_all_electric_data)
@@ -415,17 +435,21 @@ def test_computed_supervisory_control_mode(
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [
-        (0, "Idle"),
-        (8, "Discharge"),
-        (9, "Discharge - CH backup"),
-        (13, "Charge - chill cooling"),
-        (14, "Charge - dynamic prices"),
-        (15, "Charge - dynamic prices CH backup"),
-        (99, None),
+        pytest.param(0, "Idle", id="idle"),
+        pytest.param(8, "Discharge", id="discharge"),
+        pytest.param(9, "Discharge - CH backup", id="discharge-ch-backup"),
+        pytest.param(13, "Charge - chill cooling", id="charge-chill-cooling"),
+        pytest.param(14, "Charge - dynamic prices", id="charge-dynamic-prices"),
+        pytest.param(
+            15,
+            "Charge - dynamic prices CH backup",
+            id="charge-dynamic-prices-ch-backup",
+        ),
+        pytest.param(99, None, id="unknown-mode"),
     ],
 )
 def test_computed_all_e_supervisory_control_mode(
-    duo_all_electric_data, mode, expected
+    duo_all_electric_data: dict[str, Any], mode: int, expected: str | None
 ) -> None:
     """All-electric supervisory control modes map to their descriptions."""
     data = deepcopy(duo_all_electric_data)
@@ -443,13 +467,17 @@ def test_computed_tariff_types_dynamic(coordinator) -> None:
 @pytest.mark.parametrize(
     ("electricity", "gas", "expected_electricity", "expected_gas"),
     [
-        (0, 0, "Single tariff", "Single tariff"),
-        (1, 1, "Double tariff", None),  # gas has no double tariff
-        (5, 5, None, None),
+        pytest.param(0, 0, "Single tariff", "Single tariff", id="single-tariff"),
+        pytest.param(1, 1, "Double tariff", None, id="double-tariff-electricity-only"),
+        pytest.param(5, 5, None, None, id="unknown-tariffs"),
     ],
 )
 def test_computed_tariff_types_variants(
-    duo_all_electric_data, electricity, gas, expected_electricity, expected_gas
+    duo_all_electric_data: dict[str, Any],
+    electricity: int,
+    gas: int,
+    expected_electricity: str | None,
+    expected_gas: str | None,
 ) -> None:
     """Tariff type codes map to descriptions; unknown codes yield None."""
     data = deepcopy(duo_all_electric_data)

--- a/tests/components/quatt/test_config_flow_helpers.py
+++ b/tests/components/quatt/test_config_flow_helpers.py
@@ -44,16 +44,16 @@ def test_parse_battery_qr_url_strips_whitespace() -> None:
 @pytest.mark.parametrize(
     "url",
     [
-        "https://quatt.io/battery/a/b/c/d",  # wrong host
-        "https://app.quatt.example/battery/a/b/c/d",  # spoofed host
-        "https://app.quatt.io/other/a/b/c/d",  # wrong path prefix
-        "https://app.quatt.io/battery/uuid/serial",  # too few segments
-        "https://app.quatt.io/battery",  # no segments at all
-        "not a url",  # garbage
-        "",  # empty
+        pytest.param("https://quatt.io/battery/a/b/c/d", id="wrong-host"),
+        pytest.param("https://app.quatt.example/battery/a/b/c/d", id="spoofed-host"),
+        pytest.param("https://app.quatt.io/other/a/b/c/d", id="wrong-path-prefix"),
+        pytest.param("https://app.quatt.io/battery/uuid/serial", id="too-few-segments"),
+        pytest.param("https://app.quatt.io/battery", id="missing-segments"),
+        pytest.param("not a url", id="invalid-url"),
+        pytest.param("", id="empty-url"),
     ],
 )
-def test_parse_battery_qr_url_invalid(url) -> None:
+def test_parse_battery_qr_url_invalid(url: str) -> None:
     """Anything that is not a valid battery QR URL yields None."""
     assert _parse_battery_qr_url(url) is None
 
@@ -71,17 +71,17 @@ def test_parse_battery_qr_url_non_string() -> None:
 @pytest.mark.parametrize(
     ("ip", "expected"),
     [
-        ("192.168.1.10", True),
-        ("10.0.0.1", True),
-        ("::1", True),
-        ("2001:db8::1", True),
-        ("999.1.1.1", False),
-        ("192.168.1", False),
-        ("cic-hostname", False),
-        ("", False),
+        pytest.param("192.168.1.10", True, id="private-ipv4-192"),
+        pytest.param("10.0.0.1", True, id="private-ipv4-10"),
+        pytest.param("::1", True, id="ipv6-loopback"),
+        pytest.param("2001:db8::1", True, id="ipv6-documentation"),
+        pytest.param("999.1.1.1", False, id="invalid-ipv4-octet"),
+        pytest.param("192.168.1", False, id="incomplete-ipv4"),
+        pytest.param("cic-hostname", False, id="hostname"),
+        pytest.param("", False, id="empty"),
     ],
 )
-def test_is_valid_ip(ip, expected) -> None:
+def test_is_valid_ip(ip: str, expected: bool) -> None:
     """IPv4 and IPv6 addresses validate; everything else does not."""
     flow = QuattFlowHandler()
     assert flow.is_valid_ip(ip) is expected

--- a/tests/components/quatt/test_coordinator_local_cic.py
+++ b/tests/components/quatt/test_coordinator_local_cic.py
@@ -62,22 +62,34 @@ def test_get_computed_value_uses_top_level_calculation() -> None:
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [
-        (None, None),
-        (0, "Standby"),
-        (1, "Standby - heating"),
-        (2, "Heating - heatpump only"),
-        (3, "Heating - heatpump + boiler"),
-        (4, "Heating - boiler only"),
-        (5, "Chill circulation"),
-        (6, "Chill cooling"),
-        (95, "Sticky pump protection"),
-        (96, "Anti-freeze protection - boiler on"),
-        (97, "Anti-freeze protection - boiler pre-pump"),
-        (98, "Anti-freeze protection - water circulation"),
-        (99, "Fault - circulation pump on"),
-        (100, "Commissioning modes"),
-        (101, "Commissioning modes"),
-        (400, "Invalid configuration"),
+        pytest.param(None, None, id="missing-mode"),
+        pytest.param(0, "Standby", id="standby"),
+        pytest.param(1, "Standby - heating", id="standby-heating"),
+        pytest.param(2, "Heating - heatpump only", id="heating-heatpump-only"),
+        pytest.param(
+            3, "Heating - heatpump + boiler", id="heating-heatpump-and-boiler"
+        ),
+        pytest.param(4, "Heating - boiler only", id="heating-boiler-only"),
+        pytest.param(5, "Chill circulation", id="chill-circulation"),
+        pytest.param(6, "Chill cooling", id="chill-cooling"),
+        pytest.param(95, "Sticky pump protection", id="sticky-pump-protection"),
+        pytest.param(
+            96, "Anti-freeze protection - boiler on", id="anti-freeze-boiler-on"
+        ),
+        pytest.param(
+            97,
+            "Anti-freeze protection - boiler pre-pump",
+            id="anti-freeze-boiler-prepump",
+        ),
+        pytest.param(
+            98,
+            "Anti-freeze protection - water circulation",
+            id="anti-freeze-water-circulation",
+        ),
+        pytest.param(99, "Fault - circulation pump on", id="fault-circulation-pump-on"),
+        pytest.param(100, "Commissioning modes", id="commissioning-100"),
+        pytest.param(101, "Commissioning modes", id="commissioning-101"),
+        pytest.param(400, "Invalid configuration", id="invalid-configuration"),
     ],
 )
 def test_computed_supervisory_control_mode_maps_known_and_failsafe_codes(

--- a/tests/components/quatt/test_coordinator_remote_cic.py
+++ b/tests/components/quatt/test_coordinator_remote_cic.py
@@ -26,9 +26,7 @@ def make_coordinator(data: Any) -> QuattCicRemoteDataUpdateCoordinator:
 @pytest.fixture(name="coordinator")
 def coordinator_fixture() -> QuattCicRemoteDataUpdateCoordinator:
     """Return a coordinator loaded with the duo all-electric remote payload."""
-    data = json.loads(
-        (FIXTURES / "remote_cic_duo_all_electric.json").read_text()
-    )
+    data = json.loads((FIXTURES / "remote_cic_duo_all_electric.json").read_text())
     return make_coordinator(data)
 
 
@@ -58,14 +56,16 @@ def test_get_value_list_index(coordinator) -> None:
 @pytest.mark.parametrize(
     "value_path",
     [
-        "heatPumps.5.power",  # index out of range
-        "heatPumps.first.power",  # non-numeric index
-        "doesNotExist",  # missing key
-        "allEStatus.doesNotExist",  # missing nested key
-        "quattBuild.nested",  # walking into a scalar
+        pytest.param("heatPumps.5.power", id="index-out-of-range"),
+        pytest.param("heatPumps.first.power", id="non-numeric-index"),
+        pytest.param("doesNotExist", id="missing-key"),
+        pytest.param("allEStatus.doesNotExist", id="missing-nested-key"),
+        pytest.param("quattBuild.nested", id="scalar-traversal"),
     ],
 )
-def test_get_value_invalid_paths_return_default(coordinator, value_path) -> None:
+def test_get_value_invalid_paths_return_default(
+    coordinator: QuattCicRemoteDataUpdateCoordinator, value_path: str
+) -> None:
     """Invalid paths return the provided default."""
     sentinel = object()
     assert coordinator.get_value(value_path, sentinel) is sentinel

--- a/tests/components/quatt/test_device.py
+++ b/tests/components/quatt/test_device.py
@@ -3,10 +3,10 @@
 from collections.abc import Iterator
 from contextlib import ExitStack
 from dataclasses import dataclass
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from pytest import LogCaptureFixture, MonkeyPatch
+from pytest import FixtureRequest, LogCaptureFixture, MonkeyPatch
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -228,3 +228,70 @@ async def test_hub_registered_before_platforms_and_reused_on_reload(
     assert registry.async_get(hub_id).name_by_user == "My Quatt"
     assert registry.async_get(hub_id).via_device_id is None
     assert "deprecated `via_device`" not in caplog.text
+
+
+@pytest.fixture(
+    name="expected_modern_lookup_calls",
+    params=[
+        pytest.param((2025, 5, 0), id="minimum"),
+        pytest.param((2026, 7, 0), id="last-legacy"),
+        pytest.param((2026, 8, 1), id="first-modern"),
+        pytest.param((2027, 1, 1), id="next-year"),
+    ],
+)
+def expected_modern_lookup_calls_fixture(
+    request: FixtureRequest, monkeypatch: MonkeyPatch
+) -> int:
+    """Select the HA lookup API for each supported version boundary."""
+    major, minor, expected_calls = request.param
+    monkeypatch.setattr(device, "MAJOR_VERSION", major)
+    monkeypatch.setattr(device, "MINOR_VERSION", minor)
+    return expected_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("identifier", "expected_name"),
+    [
+        pytest.param("owned", "Bedroom", id="found"),
+        pytest.param("foreign", None, id="other-config-entry"),
+        pytest.param("missing", None, id="missing"),
+    ],
+)
+async def test_device_lookup_uses_supported_api_and_own_config_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    expected_modern_lookup_calls: int,
+    identifier: str,
+    expected_name: str | None,
+) -> None:
+    """Both APIs find owned devices and exclude missing or foreign devices."""
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "owned")},
+        name="Bedroom",
+    )
+    other_entry = MockConfigEntry(domain=DOMAIN, unique_id="CIC-other", data={})
+    other_entry.add_to_hass(hass)
+    registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={(DOMAIN, "foreign")},
+        name="Other bedroom",
+    )
+
+    with patch.object(
+        registry,
+        "async_get_device_by_identifier",
+        wraps=registry.async_get_device_by_identifier,
+    ) as modern_lookup:
+        result = device.async_get_device_by_identifier(
+            registry, (DOMAIN, identifier), config_entry.entry_id
+        )
+
+    assert getattr(result, "name", None) == expected_name
+    assert (
+        modern_lookup.call_args_list
+        == [call((DOMAIN, identifier), config_entry.entry_id)]
+        * expected_modern_lookup_calls
+    )

--- a/tests/components/quatt/test_entity_setup.py
+++ b/tests/components/quatt/test_entity_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -15,7 +16,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.quatt.__init__ import _sync_chill_device_names
+# tests/conftest.py exposes the core test helpers at runtime.
+from tests.common import MockConfigEntry  # pylint: disable=no-name-in-module
+
+from custom_components.quatt import _sync_chill_device_names
 from custom_components.quatt.climate import (
     CLIMATES,
     create_chill_climate_entity_descriptions,
@@ -26,6 +30,8 @@ from custom_components.quatt.entity_setup import (
     async_setup_entities,
     create_chill_entity_descriptions,
 )
+
+from custom_components.quatt.number import NUMBERS
 
 pytestmark = pytest.mark.asyncio
 
@@ -119,7 +125,7 @@ async def test_create_chill_entity_descriptions_skip_missing_uuid(
 
     assert "Cannot set up Chill at index 0: missing UUID" in caplog.text
     assert "Bedroom" not in device_names.values()
-    assert device_kinds == {}
+    assert not device_kinds
     assert "uuid-a" not in entity_descriptions
 
 
@@ -173,15 +179,79 @@ async def test_async_setup_entities_removes_obsolete_chill_device(
     )
 
 
+@pytest.mark.parametrize(
+    ("initial_name", "expected_updates"),
+    [
+        pytest.param("Old bedroom", 1, id="renamed"),
+        pytest.param("Bedroom chill", 0, id="unchanged"),
+    ],
+)
 async def test_sync_chill_device_names_updates_registry_name(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
+    initial_name: str,
+    expected_updates: int,
 ) -> None:
-    """Refreshing remote data should rename the Chill device in HA."""
+    """Refreshing remote data updates the device name and preserves user naming."""
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, f"{config_entry.unique_id}:uuid-a")},
+        name=initial_name,
+    )
+    device_registry.async_update_device(device.id, name_by_user="My bedroom")
+    coordinator = FakeRemoteCoordinator(
+        _remote_data([{"uuid": "uuid-a", "name": "Bedroom chill"}])
+    )
+
+    with patch.object(
+        device_registry,
+        "async_update_device",
+        wraps=device_registry.async_update_device,
+    ) as update_device:
+        _sync_chill_device_names(hass, config_entry, coordinator)
+
+    assert update_device.call_count == expected_updates
+    updated_device = device_registry.async_get(device.id)
+    assert updated_device.name == "Bedroom chill"
+    assert updated_device.name_by_user == "My bedroom"
+    assert updated_device.identifiers == device.identifiers
+
+
+async def test_sync_chill_device_names_skips_missing_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Name synchronization must not create devices absent from the registry."""
+    device_registry = dr.async_get(hass)
+    coordinator = FakeRemoteCoordinator(
+        _remote_data([{"uuid": "uuid-missing", "name": "Bedroom chill"}])
+    )
+
+    _sync_chill_device_names(hass, config_entry, coordinator)
+
+    assert (
+        dr.async_entries_for_config_entry(device_registry, config_entry.entry_id) == []
+    )
+
+
+async def test_sync_chill_device_names_uses_own_config_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Identical identifiers in another config entry must not redirect a rename."""
+    device_registry = dr.async_get(hass)
+    other_entry = MockConfigEntry(domain=DOMAIN, unique_id="CIC-other", data={})
+    other_entry.add_to_hass(hass)
+    identifiers = {(DOMAIN, f"{config_entry.unique_id}:uuid-a")}
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers=identifiers,
+        name="Other bedroom",
+    )
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers=identifiers,
         name="Old bedroom",
     )
     coordinator = FakeRemoteCoordinator(
@@ -190,13 +260,13 @@ async def test_sync_chill_device_names_updates_registry_name(
 
     _sync_chill_device_names(hass, config_entry, coordinator)
 
+    assert device.id != other_device.id
     assert device_registry.async_get(device.id).name == "Bedroom chill"
+    assert device_registry.async_get(other_device.id).name == "Other bedroom"
 
 
 async def test_max_water_temperature_number_has_device_class() -> None:
     """The Max water temperature number sensor should be classified as temperature."""
-    from custom_components.quatt.number import NUMBERS
-
     description = NUMBERS[DEVICE_CIC_ID][0]
 
     assert description.key == "chMaxWaterTemperature"

--- a/tests/components/quatt/test_night_window.py
+++ b/tests/components/quatt/test_night_window.py
@@ -301,10 +301,12 @@ async def test_time_native_value_defaults_minute_to_zero(
 @pytest.mark.parametrize(
     "value",
     [
-        time(hour=21, minute=15),
-        time(hour=21, minute=1),
-        time(hour=21, minute=0, second=30),
-        time(hour=21, minute=30, microsecond=1),
+        pytest.param(time(hour=21, minute=15), id="quarter-hour"),
+        pytest.param(time(hour=21, minute=1), id="off-boundary-minute"),
+        pytest.param(time(hour=21, minute=0, second=30), id="nonzero-seconds"),
+        pytest.param(
+            time(hour=21, minute=30, microsecond=1), id="nonzero-microseconds"
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/components/quatt/test_repairs.py
+++ b/tests/components/quatt/test_repairs.py
@@ -90,9 +90,9 @@ async def test_create_fix_flow_returns_remote_auth_flow(
 @pytest.mark.parametrize(
     ("issue_id", "data"),
     [
-        ("some_other_issue", {"entry_id": "abc"}),
-        ("remote_auth_failed_abc", None),
-        ("remote_auth_failed_abc", {}),
+        pytest.param("some_other_issue", {"entry_id": "abc"}, id="unknown-issue"),
+        pytest.param("remote_auth_failed_abc", None, id="missing-data"),
+        pytest.param("remote_auth_failed_abc", {}, id="missing-entry-id"),
     ],
 )
 async def test_create_fix_flow_fallback(


### PR DESCRIPTION
Chill device-name synchronization still used the deprecated device registry lookup. Use `async_get_device_by_identifier` on Home Assistant 2026.8 and newer, and look up identifiers within the config entry on older versions. Both paths restrict renaming to the current config entry and preserve names set manually in Home Assistant. The minimum supported Home Assistant version remains 2025.5.0.

Add regression coverage for the version boundary, renaming, unchanged names, missing devices, and devices belonging to another config entry. Correct the outdated mode 6 test expectation from `Cooling` to `Chill cooling`, document name synchronization, and consistently name comparable parametrized test cases with `pytest.param(..., id=...)`.

Validation:

- Full Quatt suite on Home Assistant 2026.10.0.dev0: 315 passed (one existing Home Assistant HTTP deprecation warning).
- Device-name compatibility smoke checks passed on Home Assistant 2025.5.0, 2026.8.0, and 2026.9.0.
- Ruff lint passed; formatting checks passed for the updated parametrized test files.
