### PR TITLE
Move Ruff settings into the lint configuration table

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,6 +7,7 @@ extend-exclude = [
     "examples",
 ]
 
+[lint]
 select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
@@ -43,11 +44,11 @@ ignore = [
     "E731",  # do not assign a lambda expression, use a def
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25


### PR DESCRIPTION
Ruff 0.16.6 reports deprecation warnings because `.ruff.toml` still places lint settings at the top level. Move `select` and `ignore` under `[lint]` and nest the pytest-style, pyupgrade, and mccabe sections under it.

All setting values, rule selections, exclusions, and the Python target remain unchanged.

Validation:

- `uvx --from ruff==0.16.6 ruff check .`: all checks passed, with no warnings.
- Parsed the old and new TOML and verified that only the lint table nesting changed.
- `git diff --check`: passed.
