### PR TITLE
Add persistent observed compressor start counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ Only sensors that are not already provided by the local API are added — no dup
 
 In addition, the remote API exposes **programmable day and night maximum sound levels** (normal, library, silent) as controls, and the **night time window** (start and end time, in 30-minute steps) as time entities, including a button to reset the window to the Quatt defaults.
 
+### Observed compressor starts
+
+With the Remote Mobile API enabled, each heat pump has an **Observed compressor starts** sensor (**Waargenomen compressorstarts** in Dutch). HP1 and HP2 are counted independently. Each heat pump also has a **Compressor starts tracked since** timestamp sensor (**Compressorstarts bijgehouden sinds** in Dutch), showing the date and time when its tracking began. Both sensors are enabled by default.
+
+- A measured compressor frequency of **1 Hz or higher** is treated as running. A transition from below 1 Hz to running increases the count by one.
+- At the first valid measurement, a compressor already running counts as **one** start; a stopped compressor starts at **zero**. The tracking-start sensor shows when tracking began, not when that first compressor start physically occurred. It remains unknown until the first valid measurement and retains the same date after reloads, restarts and backup restores. The date also remains available as the counter's `tracking_since` attribute.
+- Missing, invalid or unavailable readings do not mean the compressor stopped and do not reset its last known state. No minimum stop duration is imposed.
+- The sensor uses the existing remote API updates, normally **once per minute**, without making extra API requests or changing the configured interval. Existing faster updates during heat battery boost continue to work.
+
+**Accuracy:** this is a count of observed starts since tracking began, not the heat pump's lifetime start count. Stop/start cycles entirely between readings, starts during Home Assistant or API downtime, and changes hidden by delayed API data may be missed. After an interruption, the last known state is compared with the next valid reading; intermediate starts cannot be reconstructed.
+
+**Persistence and backups:** both counters, their `tracking_since` timestamps and their last known running states are stored together in Home Assistant's `.storage` directory. Changes are saved at each observed start or stop, so the values survive integration reloads and Home Assistant restarts without recounting a continuously running compressor. Renaming the sensors does not reset them. Backups that include the Home Assistant configuration also include these values; restoring that configuration restores the saved counts as of the backup, not any starts recorded afterwards. Deleting the integration entry removes its counters; adding it again starts a new tracking period.
+
 ### Enabling
 
 The Remote Mobile API can be enabled either while adding the CIC for the first time, or on an existing CIC.

--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -61,6 +61,7 @@ from .coordinator_home_battery import QuattHomeBatteryDataUpdateCoordinator
 from .coordinator_local_cic import QuattCicLocalDataUpdateCoordinator
 from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
 from .coordinator_remote_energy import QuattEnergyDataUpdateCoordinator
+from .compressor_starts import CompressorStartCounter
 from .device import async_get_device_by_identifier
 from .repairs import (
     async_create_remote_auth_issue,
@@ -664,6 +665,7 @@ def _entry_uses_remote_auth(entry: ConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Clean up per-hub storage (and shared auth when the last remote hub leaves)."""
+    await CompressorStartCounter(hass, entry.entry_id).async_remove()
     is_energy = CONF_ENERGY_USERNAME in entry.data
     if entry.unique_id and (_entry_uses_remote_auth(entry) or is_energy):
         hub_store = Store(

--- a/custom_components/quatt/compressor_starts.py
+++ b/custom_components/quatt/compressor_starts.py
@@ -1,0 +1,100 @@
+"""Persist observed compressor starts independently of sensor entities."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import math
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+COMPRESSOR_ON_HZ = 1.0
+STORAGE_VERSION = 1
+
+
+@dataclass
+class CompressorStartState:
+    """The count and last known state of one compressor."""
+
+    count: int = 0
+    running: bool | None = None
+    tracking_since: str | None = None
+
+    def update(self, frequency: Any, now: datetime) -> bool:
+        """Count an observed start, ignoring missing or invalid measurements."""
+        if isinstance(frequency, bool) or not isinstance(frequency, (int, float, str)):
+            return False
+        try:
+            value = float(frequency)
+        except (ValueError, OverflowError):
+            return False
+        if not math.isfinite(value) or value < 0:
+            return False
+
+        running = value >= COMPRESSOR_ON_HZ
+        if running == self.running:
+            return False
+        if self.tracking_since is None:
+            self.tracking_since = now.isoformat()
+        if running:
+            self.count += 1
+        self.running = running
+        return True
+
+
+class CompressorStartCounter:
+    """Keep independent HP1/HP2 counts in versioned, per-entry storage."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize storage without performing I/O."""
+        self._store = Store(
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}.compressor_starts.{entry_id}",
+            atomic_writes=True,
+        )
+        self.states = [CompressorStartState(), CompressorStartState()]
+        self._loaded = False
+
+    async def async_load(self) -> None:
+        """Restore both counters before processing the first API response."""
+        if self._loaded:
+            return
+        stored = await self._store.async_load()
+        if stored is not None:
+            self.states = [
+                CompressorStartState(**stored[key]) for key in ("hp1", "hp2")
+            ]
+        self._loaded = True
+
+    async def async_update(self, data: Any, now: datetime) -> None:
+        """Process existing API measurements and save only state transitions."""
+        await self.async_load()
+        if not isinstance(data, dict):
+            return
+        result = data.get("result", data)
+        if not isinstance(result, dict):
+            return
+        heatpumps = result.get("heatPumps")
+        if not isinstance(heatpumps, list):
+            return
+
+        changed = False
+        for index, pump in enumerate(heatpumps[:2]):
+            if isinstance(pump, dict):
+                changed |= self.states[index].update(
+                    pump.get("compressorFrequency"), now
+                )
+        if changed:
+            # Persist stops too, so the next start is recognized after a reload.
+            await self._store.async_save(
+                {"hp1": asdict(self.states[0]), "hp2": asdict(self.states[1])}
+            )
+
+    async def async_remove(self) -> None:
+        """Remove counters only when the config entry is deleted."""
+        await self._store.async_remove()

--- a/custom_components/quatt/coordinator_remote_cic.py
+++ b/custom_components/quatt/coordinator_remote_cic.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from .api import QuattApiClient
+from .compressor_starts import CompressorStartCounter
 from .const import (
     BOOST_ACTIVE_STATUSES,
     BOOST_FAST_SCAN_INTERVAL,
@@ -32,12 +33,17 @@ class QuattCicRemoteDataUpdateCoordinator(QuattCicDataUpdateCoordinator):
     ) -> None:
         """Initialize the remote CIC coordinator."""
         super().__init__(hass=hass, update_interval=update_interval, client=client)
+        self.compressor_starts = CompressorStartCounter(
+            hass, self.config_entry.entry_id
+        )
         self._configured_update_interval = update_interval
         self._boost_fast_scan_until: datetime | None = None
 
-    async def _async_update_data(self):
-        """Fetch data and adapt the poll interval to the boost state."""
+    async def _async_update_data(self) -> Any:
+        """Fetch data, persist observed starts and adapt the boost poll interval."""
+        await self.compressor_starts.async_load()
         data = await super()._async_update_data()
+        await self.compressor_starts.async_update(data, dt_util.utcnow())
         self.update_interval = self._next_update_interval(data)
         return data
 

--- a/custom_components/quatt/sensor_compressor_starts.py
+++ b/custom_components/quatt/sensor_compressor_starts.py
@@ -1,0 +1,49 @@
+"""Sensors exposing the coordinator's persisted compressor start counts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import homeassistant.util.dt as dt_util
+
+from .compressor_starts import CompressorStartState
+from .const import DEVICE_HEATPUMP_1_ID, DEVICE_HEATPUMP_2_ID
+from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
+from .entity import QuattSensor
+
+
+class QuattCompressorTrackingSensor(QuattSensor):
+    """Read the stored tracking state for a heat pump."""
+
+    coordinator: QuattCicRemoteDataUpdateCoordinator
+
+    @property
+    def _counter(self) -> CompressorStartState:
+        """Return the stored counter belonging to this heat pump device."""
+        index = (DEVICE_HEATPUMP_1_ID, DEVICE_HEATPUMP_2_ID).index(self._device_id)
+        return self.coordinator.compressor_starts.states[index]
+
+
+class QuattObservedCompressorStartsSensor(QuattCompressorTrackingSensor):
+    """Report observed starts without changing the counter when read."""
+
+    @property
+    def native_value(self) -> int | None:
+        """Return unknown until this compressor has a valid first measurement."""
+        state = self._counter
+        return state.count if state.tracking_since is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Expose the original start of tracking across reloads and restores."""
+        return {"tracking_since": self._counter.tracking_since}
+
+
+class QuattCompressorTrackingSinceSensor(QuattCompressorTrackingSensor):
+    """Show when observation of this compressor began."""
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the persisted start of tracking as a timezone-aware timestamp."""
+        since = self._counter.tracking_since
+        return dt_util.parse_datetime(since) if since is not None else None

--- a/custom_components/quatt/sensor_descriptions_heat.py
+++ b/custom_components/quatt/sensor_descriptions_heat.py
@@ -12,6 +12,10 @@ from homeassistant.const import (
 )
 
 from .entity import QuattFeatureFlags, QuattSensorEntityDescription
+from .sensor_compressor_starts import (
+    QuattCompressorTrackingSinceSensor,
+    QuattObservedCompressorStartsSensor,
+)
 
 
 def create_heatpump_sensor_entity_descriptions(
@@ -121,6 +125,28 @@ def create_heatpump_sensor_entity_descriptions(
             entity_category=EntityCategory.DIAGNOSTIC,
             quatt_features=QuattFeatureFlags(
                 duo=is_duo,
+            ),
+        ),
+        QuattSensorEntityDescription(
+            key=f"{prefix}.observedCompressorStarts",
+            translation_key="observed_compressor_starts",
+            icon="mdi:counter",
+            state_class=SensorStateClass.TOTAL,
+            suggested_display_precision=0,
+            quatt_entity_class=QuattObservedCompressorStartsSensor,
+            quatt_features=QuattFeatureFlags(
+                duo=is_duo,
+                mobile_api=True,
+            ),
+        ),
+        QuattSensorEntityDescription(
+            key=f"{prefix}.compressorTrackingSince",
+            translation_key="compressor_tracking_since",
+            device_class=SensorDeviceClass.TIMESTAMP,
+            quatt_entity_class=QuattCompressorTrackingSinceSensor,
+            quatt_features=QuattFeatureFlags(
+                duo=is_duo,
+                mobile_api=True,
             ),
         ),
         QuattSensorEntityDescription(

--- a/custom_components/quatt/strings.json
+++ b/custom_components/quatt/strings.json
@@ -142,5 +142,15 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "observed_compressor_starts": {
+                "name": "Observed compressor starts"
+            },
+            "compressor_tracking_since": {
+                "name": "Compressor starts tracked since"
+            }
+        }
     }
 }

--- a/custom_components/quatt/translations/en.json
+++ b/custom_components/quatt/translations/en.json
@@ -148,5 +148,15 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "observed_compressor_starts": {
+                "name": "Observed compressor starts"
+            },
+            "compressor_tracking_since": {
+                "name": "Compressor starts tracked since"
+            }
+        }
     }
 }

--- a/custom_components/quatt/translations/nl.json
+++ b/custom_components/quatt/translations/nl.json
@@ -142,5 +142,15 @@
                 }
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "observed_compressor_starts": {
+                "name": "Waargenomen compressorstarts"
+            },
+            "compressor_tracking_since": {
+                "name": "Compressorstarts bijgehouden sinds"
+            }
+        }
     }
 }

--- a/tests/components/quatt/test_compressor_starts.py
+++ b/tests/components/quatt/test_compressor_starts.py
@@ -1,0 +1,585 @@
+"""Tests for observed compressor starts and their persistent state."""
+# pylint: disable=import-error,no-name-in-module
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import current_entry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import frame, device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_platform import EntityPlatform
+from homeassistant.helpers.storage import Store
+from homeassistant.loader import DATA_CUSTOM_COMPONENTS, Integration
+
+from tests.common import MockConfigEntry, async_test_home_assistant
+
+from custom_components.quatt.api import QuattApiClient, QuattApiClientCommunicationError
+from custom_components.quatt.compressor_starts import (
+    CompressorStartCounter,
+    CompressorStartState,
+)
+from custom_components.quatt import async_remove_entry
+from custom_components.quatt.const import (
+    DOMAIN,
+    DEVICE_HEATPUMP_1_ID,
+    DEVICE_HEATPUMP_2_ID,
+    QuattDeviceKind,
+)
+from custom_components.quatt.entity_setup import async_setup_entities
+from custom_components.quatt.sensor import SENSORS
+from custom_components.quatt.sensor_compressor_starts import (
+    QuattCompressorTrackingSensor,
+    QuattCompressorTrackingSinceSensor,
+    QuattObservedCompressorStartsSensor,
+)
+from custom_components.quatt.sensor_descriptions_heat import (
+    create_heatpump_sensor_entity_descriptions,
+)
+from custom_components.quatt.coordinator_remote_cic import (
+    QuattCicRemoteDataUpdateCoordinator,
+)
+
+NOW = datetime(2026, 9, 8, 12, tzinfo=UTC)
+
+
+def payload(hp1: object, hp2: object = None) -> dict:
+    """Return a duo remote API response with independent frequencies."""
+    return {
+        "result": {
+            "heatPumps": [{"compressorFrequency": hp1}, {"compressorFrequency": hp2}]
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("frequency", "count", "running"),
+    [
+        pytest.param(0, 0, False, id="stopped"),
+        pytest.param(0.9, 0, False, id="residual-frequency"),
+        pytest.param(1, 1, True, id="threshold"),
+        pytest.param(30, 1, True, id="already-running"),
+        pytest.param("30", 1, True, id="numeric-string"),
+    ],
+)
+def test_first_measurement(frequency: object, count: int, running: bool) -> None:
+    """The first valid observation starts tracking and counts a running unit."""
+    state = CompressorStartState()
+    assert state.update(frequency, NOW)
+    assert state == CompressorStartState(count, running, NOW.isoformat())
+
+
+@pytest.mark.parametrize(
+    "frequency",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("unavailable", id="unavailable"),
+        pytest.param("unknown", id="unknown"),
+        pytest.param("", id="empty"),
+        pytest.param(True, id="boolean"),
+        pytest.param(-1, id="negative"),
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="infinity"),
+        pytest.param("NaN", id="nan-string"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="mapping"),
+    ],
+)
+def test_invalid_measurements_preserve_state(frequency: object) -> None:
+    """Invalid readings neither initialize tracking nor manufacture stops."""
+    uninitialized = CompressorStartState()
+    assert not uninitialized.update(frequency, NOW)
+    assert uninitialized == CompressorStartState()
+    running = CompressorStartState(4, True, NOW.isoformat())
+    assert not running.update(frequency, NOW + timedelta(minutes=1))
+    assert not running.update(40, NOW + timedelta(minutes=2))
+    assert running == CompressorStartState(4, True, NOW.isoformat())
+
+
+def test_only_transitions_count() -> None:
+    """Modulation does not count; even a short observed stop remains a stop."""
+    state = CompressorStartState()
+    state.update(0, NOW)
+    state.update(30, NOW + timedelta(minutes=1))
+    assert not state.update(50, NOW + timedelta(minutes=2))
+    state.update(0, NOW + timedelta(minutes=3))
+    state.update(30, NOW + timedelta(minutes=3, seconds=30))
+    assert state == CompressorStartState(2, True, NOW.isoformat())
+
+
+@pytest.fixture(name="counter")
+def counter_fixture(hass: HomeAssistant, tmp_path: Path) -> CompressorStartCounter:
+    """Use actual HA storage in a temporary configuration directory."""
+    hass.config.config_dir = str(tmp_path)
+    return CompressorStartCounter(hass, "test-entry")
+
+
+@pytest.mark.asyncio
+async def test_independent_counters_and_reload(
+    hass: HomeAssistant, counter: CompressorStartCounter, tmp_path: Path
+) -> None:
+    """Persist starts and stops before reloading, including tracking timestamps."""
+    await counter.async_update(payload(30, 0), NOW)
+    await counter.async_update(payload(40, 30), NOW + timedelta(minutes=1))
+    await counter.async_update(payload(0, None), NOW + timedelta(minutes=2))
+    path = tmp_path / ".storage" / "quatt.compressor_starts.test-entry"
+    saved = json.loads(path.read_text())["data"]
+    assert saved == {
+        "hp1": {"count": 1, "running": False, "tracking_since": NOW.isoformat()},
+        "hp2": {"count": 1, "running": True, "tracking_since": NOW.isoformat()},
+    }
+
+    reloaded = CompressorStartCounter(hass, "test-entry")
+    await reloaded.async_update(payload(30, 45), NOW + timedelta(minutes=3))
+    assert reloaded.states == [
+        CompressorStartState(2, True, NOW.isoformat()),
+        CompressorStartState(1, True, NOW.isoformat()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_saves_only_changes(counter: CompressorStartCounter) -> None:
+    """Unchanged polls and missing data do not write storage repeatedly."""
+    with patch.object(Store, "async_save") as save:
+        await counter.async_update(payload(0), NOW)
+        await counter.async_update(payload(0), NOW)
+        await counter.async_update(payload(None), NOW)
+        assert save.call_count == 1
+        await counter.async_update(payload(30), NOW)
+        await counter.async_update(payload(40), NOW)
+        assert save.call_count == 2
+        await counter.async_update(payload(0), NOW)
+        assert save.call_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(None, id="no-response"),
+        pytest.param({}, id="missing-pumps"),
+        pytest.param({"result": None}, id="null-result"),
+        pytest.param({"heatPumps": None}, id="null-pumps"),
+        pytest.param({"heatPumps": {}}, id="invalid-pumps"),
+        pytest.param({"heatPumps": [None, {}]}, id="missing-frequency"),
+    ],
+)
+async def test_incomplete_response_preserves_counts(
+    counter: CompressorStartCounter, data: object
+) -> None:
+    """Missing pumps or invalid payloads cannot reset or initialize counters."""
+    await counter.async_update(payload(30), NOW)
+    await counter.async_update(data, NOW + timedelta(minutes=1))
+    await counter.async_update(payload(30), NOW + timedelta(minutes=2))
+    assert counter.states == [
+        CompressorStartState(1, True, NOW.isoformat()),
+        CompressorStartState(),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_config_entries_do_not_share_storage(
+    hass: HomeAssistant, counter: CompressorStartCounter
+) -> None:
+    """Separate CICs retain their own counts even when both expose HP1."""
+    other = CompressorStartCounter(hass, "other-entry")
+    await counter.async_update(payload(30), NOW)
+    await other.async_update(payload(0), NOW)
+    await other.async_load()
+    assert other.states[0].count == 0
+    await counter.async_remove()
+    restored_other = CompressorStartCounter(hass, "other-entry")
+    await restored_other.async_load()
+    assert restored_other.states[0] == CompressorStartState(0, False, NOW.isoformat())
+    removed = CompressorStartCounter(hass, "test-entry")
+    await removed.async_update(payload(30), NOW + timedelta(days=1))
+    assert removed.states[0].tracking_since == (NOW + timedelta(days=1)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_restart_and_backup_restore(tmp_path: Path) -> None:
+    """A new HA instance restores disk data, including an older backup snapshot."""
+    original_dir = tmp_path / "original"
+    restore_dir = tmp_path / "restored"
+    async with async_test_home_assistant(config_dir=str(original_dir)) as first_hass:
+        counter = CompressorStartCounter(first_hass, "saved-entry")
+        await counter.async_update(payload(30, 0), NOW)
+        storage_file = original_dir / ".storage" / "quatt.compressor_starts.saved-entry"
+        backup_bytes = storage_file.read_bytes()
+        await counter.async_update(payload(0, 0), NOW + timedelta(minutes=1))
+        await counter.async_update(payload(30, 0), NOW + timedelta(minutes=2))
+
+    async with async_test_home_assistant(
+        config_dir=str(original_dir)
+    ) as restarted_hass:
+        counter = CompressorStartCounter(restarted_hass, "saved-entry")
+        await counter.async_update(payload(40, 0), NOW + timedelta(minutes=3))
+        assert counter.states[0] == CompressorStartState(2, True, NOW.isoformat())
+
+    restored_file = restore_dir / ".storage" / storage_file.name
+    restored_file.parent.mkdir(parents=True)
+    restored_file.write_bytes(backup_bytes)
+    async with async_test_home_assistant(config_dir=str(restore_dir)) as restored_hass:
+        counter = CompressorStartCounter(restored_hass, "saved-entry")
+        await counter.async_update(payload(40, 0), NOW + timedelta(days=1))
+        assert counter.states[0] == CompressorStartState(1, True, NOW.isoformat())
+
+
+@pytest.fixture(name="remote_coordinator")
+def remote_coordinator_fixture(
+    hass: HomeAssistant, config_entry: MockConfigEntry, tmp_path: Path
+) -> Iterator[QuattCicRemoteDataUpdateCoordinator]:
+    """Run a real remote coordinator with only network I/O mocked."""
+    hass.config.config_dir = str(tmp_path)
+    frame.async_setup(hass)
+    token = current_entry.set(config_entry)
+    client = AsyncMock(spec=QuattApiClient)
+    try:
+        coordinator = QuattCicRemoteDataUpdateCoordinator(
+            hass, timedelta(minutes=1), client
+        )
+        coordinator.hub_device_id = "hub-registry-id"
+        yield coordinator
+    finally:
+        current_entry.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_counts_without_entities_or_extra_requests(
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+) -> None:
+    """Counting uses existing polls, including the first, without sensor listeners."""
+    remote_coordinator.client.async_get_data.side_effect = [
+        payload(30, 0),
+        payload(40, 0),
+        payload(0, 30),
+        payload(30, 40),
+    ]
+    await remote_coordinator.async_refresh()
+    await remote_coordinator.async_refresh()
+    await remote_coordinator.async_refresh()
+    await remote_coordinator.async_refresh()
+    assert [state.count for state in remote_coordinator.compressor_starts.states] == [
+        2,
+        1,
+    ]
+    assert remote_coordinator.client.async_get_data.await_count == 4
+    assert remote_coordinator.update_interval == timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_api_failure_does_not_create_a_stop(
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+) -> None:
+    """A connection outage cannot cause a continuously running unit to count twice."""
+    remote_coordinator.client.async_get_data.side_effect = [
+        payload(30),
+        QuattApiClientCommunicationError("offline"),
+        payload(40),
+    ]
+    await remote_coordinator.async_refresh()
+    await remote_coordinator.async_refresh()
+    assert not remote_coordinator.last_update_success
+    await remote_coordinator.async_refresh()
+    assert remote_coordinator.last_update_success
+    assert remote_coordinator.compressor_starts.states[0].count == 1
+
+
+def make_sensor(
+    coordinator: QuattCicRemoteDataUpdateCoordinator,
+    index: int,
+    translation_key: str = "observed_compressor_starts",
+) -> QuattCompressorTrackingSensor:
+    """Construct a tracking sensor using the production description and factory."""
+    description = next(
+        desc
+        for desc in create_heatpump_sensor_entity_descriptions(index, index == 1)
+        if desc.translation_key == translation_key
+    )
+    return description.quatt_entity_class(
+        device_name=f"Heatpump {index + 1}",
+        device_id=(DEVICE_HEATPUMP_1_ID, DEVICE_HEATPUMP_2_ID)[index],
+        sensor_key=description.key,
+        coordinator=coordinator,
+        entity_description=description,
+        device_kind=QuattDeviceKind.DEVICE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_is_passive(
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+) -> None:
+    """Reading a sensor cannot count starts or initialize an unseen compressor."""
+    hp1 = make_sensor(remote_coordinator, 0)
+    hp2 = make_sensor(remote_coordinator, 1)
+    assert hp1.native_value is None
+    assert hp1.extra_state_attributes == {"tracking_since": None}
+    await remote_coordinator.compressor_starts.async_update(payload(30), NOW)
+    assert hp1.native_value == 1
+    assert hp1.native_value == 1
+    assert hp2.native_value is None
+    assert hp1.extra_state_attributes == {"tracking_since": NOW.isoformat()}
+    recreated = make_sensor(remote_coordinator, 0)
+    assert recreated.native_value == 1
+    assert recreated.unique_id == hp1.unique_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "index",
+    [pytest.param(0, id="hp1"), pytest.param(1, id="hp2")],
+)
+@pytest.mark.parametrize(
+    ("translation_key", "expected"),
+    [
+        pytest.param("observed_compressor_starts", 1, id="count"),
+        pytest.param("compressor_tracking_since", NOW, id="tracking-since"),
+    ],
+)
+async def test_tracking_sensors_do_not_query_api_values(
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+    index: int,
+    translation_key: str,
+    expected: int | datetime,
+) -> None:
+    """Tracking values come from persisted state without raw or computed lookup."""
+    await remote_coordinator.compressor_starts.async_update(payload(30, 40), NOW)
+    sensor = make_sensor(remote_coordinator, index, translation_key)
+    with (
+        patch.object(remote_coordinator, "get_value") as raw_lookup,
+        patch.object(remote_coordinator, "get_computed_value") as computed_lookup,
+    ):
+        assert sensor.native_value == expected
+        raw_lookup.assert_not_called()
+        computed_lookup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tracking_since_sensor_uses_each_pumps_first_valid_reading(
+    hass: HomeAssistant,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+) -> None:
+    """Dates start independently, remain fixed on new starts and survive reload."""
+    hp1 = make_sensor(remote_coordinator, 0, "compressor_tracking_since")
+    hp2 = make_sensor(remote_coordinator, 1, "compressor_tracking_since")
+    assert hp1.native_value is None
+    assert hp2.native_value is None
+    await remote_coordinator.compressor_starts.async_update(payload(30, None), NOW)
+    assert hp1.native_value == NOW
+    assert hp2.native_value is None
+    later = NOW + timedelta(minutes=1)
+    await remote_coordinator.compressor_starts.async_update(payload(0, 0), later)
+    await remote_coordinator.compressor_starts.async_update(
+        payload(30, 30), NOW + timedelta(minutes=2)
+    )
+    assert hp1.native_value == NOW
+    assert hp2.native_value == later
+    remote_coordinator.compressor_starts = CompressorStartCounter(
+        hass, remote_coordinator.config_entry.entry_id
+    )
+    await remote_coordinator.compressor_starts.async_load()
+    assert hp1.native_value == NOW
+    assert hp2.native_value == later
+    assert hp1.device_class == SensorDeviceClass.TIMESTAMP
+    assert hp1.entity_registry_enabled_default
+    assert hp1.entity_description.entity_category is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("count", "remote", "expected"),
+    [
+        pytest.param(1, True, ["heatpump_1"], id="remote-mono"),
+        pytest.param(2, True, ["heatpump_1", "heatpump_2"], id="remote-duo"),
+        pytest.param(2, False, [], id="local-only"),
+    ],
+)
+async def test_counter_entity_selection(
+    hass: HomeAssistant,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+    count: int,
+    remote: bool,
+    expected: list[str],
+) -> None:
+    """Counter sensors follow the existing mono/duo and remote feature flags."""
+    config_entry = remote_coordinator.config_entry
+    remote_coordinator.data = {"heatPumps": [{"compressorFrequency": 0}] * count}
+    entities = await async_setup_entities(
+        hass, remote_coordinator, config_entry, remote, SENSORS, "sensor"
+    )
+    counters = [
+        entity
+        for entity in entities
+        if isinstance(entity, QuattObservedCompressorStartsSensor)
+    ]
+    assert [
+        next(iter(entity.device_info["identifiers"]))[1] for entity in counters
+    ] == [f"{config_entry.unique_id}:{device_id}" for device_id in expected]
+    tracking_dates = [
+        entity
+        for entity in entities
+        if isinstance(entity, QuattCompressorTrackingSinceSensor)
+    ]
+    assert [
+        next(iter(entity.device_info["identifiers"]))[1] for entity in tracking_dates
+    ] == [f"{config_entry.unique_id}:{device_id}" for device_id in expected]
+
+
+def make_entity_platform(
+    hass: HomeAssistant,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+    language: str,
+) -> EntityPlatform:
+    """Load real integration metadata and attach a sensor platform to the CIC."""
+    config_entry = remote_coordinator.config_entry
+    hass.config.language = language
+    integration_path = (
+        Path(__file__).resolve().parents[3] / "custom_components" / DOMAIN
+    )
+    hass.data[DATA_CUSTOM_COMPONENTS] = {
+        DOMAIN: Integration(
+            hass,
+            "custom_components.quatt",
+            integration_path,
+            json.loads((integration_path / "manifest.json").read_text()),
+            top_level_files={"translations"},
+        )
+    }
+    hub = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, config_entry.unique_id)},
+    )
+    remote_coordinator.hub_device_id = hub.id
+    platform = EntityPlatform(
+        hass=hass,
+        logger=logging.getLogger(__name__),
+        domain="sensor",
+        platform_name=DOMAIN,
+        platform=None,
+        scan_interval=timedelta(minutes=1),
+        entity_namespace=None,
+    )
+    platform.config_entry = config_entry
+    return platform
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "expected_name", "expected_since_name"),
+    [
+        pytest.param(
+            "en",
+            "Observed compressor starts",
+            "Compressor starts tracked since",
+            id="english",
+        ),
+        pytest.param(
+            "nl",
+            "Waargenomen compressorstarts",
+            "Compressorstarts bijgehouden sinds",
+            id="dutch",
+        ),
+    ],
+)
+async def test_entity_reload_preserves_name_id_and_counter(
+    hass: HomeAssistant,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+    language: str,
+    expected_name: str,
+    expected_since_name: str,
+) -> None:
+    """Real entity registration survives setup cleanup, renaming and reloading."""
+    platform = make_entity_platform(hass, remote_coordinator, language)
+    remote_coordinator.client.async_get_data.return_value = payload(30, 0)
+    await remote_coordinator.async_refresh()
+    sensor = make_sensor(remote_coordinator, 0)
+    tracking_date = make_sensor(remote_coordinator, 0, "compressor_tracking_since")
+    await platform.platform_data.async_load_translations()
+    await platform.async_add_entities([sensor, tracking_date])
+    assert tracking_date.name == expected_since_name
+    assert sensor.name == expected_name
+    entity_id = sensor.entity_id
+    assert hass.states.get(entity_id).state == "1"
+    since = hass.states.get(entity_id).attributes["tracking_since"]
+    date_entity_id = tracking_date.entity_id
+    assert tracking_date.native_value == datetime.fromisoformat(since)
+    assert (
+        hass.states.get(date_entity_id).state
+        == datetime.fromisoformat(since).replace(microsecond=0).isoformat()
+    )
+    assert hass.states.get(date_entity_id).attributes["device_class"] == "timestamp"
+    registry = er.async_get(hass)
+    original_ids = (
+        registry.async_get(entity_id).id,
+        registry.async_get(date_entity_id).id,
+    )
+    registry.async_update_entity(entity_id, name="My compressor counter")
+    await hass.async_block_till_done()
+    await platform.async_reset()
+
+    # Both local and remote setup perform registry cleanup on a real reload.
+    await async_setup_entities(
+        hass,
+        remote_coordinator,
+        remote_coordinator.config_entry,
+        False,
+        SENSORS,
+        "sensor",
+    )
+    await async_setup_entities(
+        hass,
+        remote_coordinator,
+        remote_coordinator.config_entry,
+        True,
+        SENSORS,
+        "sensor",
+    )
+    assert registry.async_get(entity_id).id == original_ids[0]
+    assert registry.async_get(date_entity_id).id == original_ids[1]
+    assert registry.async_get(entity_id).name == "My compressor counter"
+    remote_coordinator.compressor_starts = CompressorStartCounter(
+        hass, remote_coordinator.config_entry.entry_id
+    )
+    await remote_coordinator.async_refresh()
+    recreated = make_sensor(remote_coordinator, 0)
+    restored_date = make_sensor(remote_coordinator, 0, "compressor_tracking_since")
+    await platform.async_add_entities([recreated, restored_date])
+    assert restored_date.entity_id == date_entity_id
+    assert (
+        hass.states.get(date_entity_id).state
+        == datetime.fromisoformat(since).replace(microsecond=0).isoformat()
+    )
+    assert recreated.entity_id == entity_id
+    assert hass.states.get(entity_id).state == "1"
+    assert hass.states.get(entity_id).attributes["tracking_since"] == since
+    assert (
+        hass.states.get(entity_id).attributes["friendly_name"]
+        == "My compressor counter"
+    )
+    await platform.async_reset()
+
+
+@pytest.mark.asyncio
+async def test_removing_entry_removes_its_counter(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+    tmp_path: Path,
+) -> None:
+    """Deleting the integration removes its store, unlike unloading it."""
+    await remote_coordinator.compressor_starts.async_update(payload(30), NOW)
+    storage_path = (
+        tmp_path / ".storage" / f"quatt.compressor_starts.{config_entry.entry_id}"
+    )
+    assert storage_path.exists()
+    await async_remove_entry(hass, config_entry)
+    assert not storage_path.exists()

--- a/tests/components/quatt/test_sensor_descriptions_fixture.py
+++ b/tests/components/quatt/test_sensor_descriptions_fixture.py
@@ -14,6 +14,7 @@ from custom_components.quatt.coordinator_local_cic import (
 from custom_components.quatt.coordinator_remote_cic import (
     QuattCicRemoteDataUpdateCoordinator,
 )
+from custom_components.quatt.entity import QuattSensor, QuattSensorEntityDescription
 from custom_components.quatt.sensor_descriptions_cic import (
     CIC_SENSORS,
     FLOWMETER_SENSORS,
@@ -90,7 +91,7 @@ def test_local_description_keys_resolve_against_fixture(description) -> None:
 
 
 def _remote_descriptions():
-    """Yield remote (mobile API) heatpump descriptions for the duo system."""
+    """Yield remote descriptions using the standard raw API value lookup."""
     tables = {
         "CIC_SENSORS": CIC_SENSORS,
         "HEATPUMP_1": create_heatpump_sensor_entity_descriptions(
@@ -108,12 +109,16 @@ def _remote_descriptions():
                 continue
             if description.computed_key:
                 continue
+            if description.quatt_entity_class.native_value is not QuattSensor.native_value:
+                continue
             yield pytest.param(description, id=f"{table_name}:{description.key}")
 
 
 @pytest.mark.parametrize("description", list(_remote_descriptions()))
-def test_remote_description_keys_resolve_against_fixture(description) -> None:
-    """Every applicable remote sensor key resolves in a real API payload."""
+def test_remote_description_keys_resolve_against_fixture(
+    description: QuattSensorEntityDescription,
+) -> None:
+    """Every remote sensor using raw lookup resolves in a real API payload."""
     coordinator = _remote_coordinator()
     value = coordinator.get_value(description.raw_value_key, SENTINEL)
     assert value is not SENTINEL, (


### PR DESCRIPTION
Adds an **Observed compressor starts** counter and a **Compressor starts tracked since** timestamp sensor to each heat pump when the Remote Mobile API is enabled. HP1 and HP2 are tracked independently, with English and Dutch sensor names.

The existing remote updates detect transitions from below 1 Hz to at least 1 Hz. A compressor already running at the first valid reading counts as one start. Counts, tracking timestamps and the last known running states are persisted per config entry, so reloading or restarting while a compressor keeps running does not count another start. Configuration backups preserve the saved values. Removing the config entry removes its counters.

No extra API requests are added and the configured polling interval is unchanged. Missing or invalid readings preserve the last known state. These are observed counts, not lifetime totals: cycles between readings or during downtime may be missed. The README explains these limits and backup/restore behavior.

Validation:
- Full Quatt test suite: **356 passed** (one existing Home Assistant HTTP deprecation warning).
- Ruff 0.16.6: all checks passed.
- Regression coverage includes first readings, frequency thresholds, missing/invalid data, API failures, independent pumps, reload/restart and backup restoration, sensor registration, translations, user renames and passive sensor reads.

Closes #242.
